### PR TITLE
audio: stream long files in bounded segments

### DIFF
--- a/Sources/OmniKit/Indexer.swift
+++ b/Sources/OmniKit/Indexer.swift
@@ -115,6 +115,9 @@ final class DecodedItem: @unchecked Sendable {
     // streams them in small groups instead, so every page of any-length scan gets indexed.
     enum Payload { case empty, text([TextPiece]), images([CGImage]), imagePatches([OmniVisionPreprocess.RawPatches]), audioMel([Float], Int),
                    pdfScan(pageCount: Int, maxDimension: Int),
+                   // Long audio (> one 240 s segment): the first segment's mel plus the open
+                   // reader; the embed stage streams the rest with a prefetch, like .pdfScan.
+                   audioSegments(mel: [Float], frames: Int, reader: OmniAudioPreprocess.AudioSegmentReader),
                    duplicate([IndexedChunk]) }   // content-dedup hit: rows ready to store, no embed needed
     let file: CrawledFile
     let kind: String
@@ -472,6 +475,11 @@ public final class Indexer: @unchecked Sendable {
                     defer { tick(path) }
                     if item.unchanged { p.unchanged += 1; return }
                     if case .duplicate(let chunks) = item.payload { storeChunks(path, chunks); return }
+                    if case .audioSegments = item.payload {
+                        // Long audio streams per-file (one embedding per 240 s segment); the
+                        // cross-file mel staging below is for clips within one frame budget.
+                        storeChunks(path, self.embed(item)); return
+                    }
                     guard case .audioMel(let mel, let frames) = item.payload else { p.skipped += 1; return }
                     // Flush before adding if this clip would exceed the budget (but never
                     // split a single clip; a clip larger than the budget embeds alone).
@@ -950,8 +958,20 @@ public final class Indexer: @unchecked Sendable {
             return frames.isEmpty ? DecodedItem(file: file) : DecodedItem(file: file, kind: kind, payload: .images(frames), meta: meta, contentKey: contentKey)
         }
         if category == .audio {
-            guard let (mel, frames) = OmniAudioPreprocess.melFeatures(url: file.url) else { return DecodedItem(file: file) }
-            return DecodedItem(file: file, kind: kind, payload: .audioMel(mel, frames), meta: meta, contentKey: contentKey)
+            // Stream-decode in bounded segments (issue #7: a whole-file PCM buffer for a
+            // multi-hour file overflows AudioToolbox's 32-bit byte count and killed the scan).
+            // One segment (the overwhelmingly common case, <= 240 s) keeps the exact old
+            // .audioMel path - byte-identical mel, cross-file batching preserved. Longer files
+            // carry the open reader to the embed stage, which streams one embedding per segment.
+            guard let reader = OmniAudioPreprocess.AudioSegmentReader(url: file.url),
+                  let first = reader.nextMelSegment(), first.frames > 0 else { return DecodedItem(file: file) }
+            guard let second = reader.nextMelSegment() else {
+                return DecodedItem(file: file, kind: kind, payload: .audioMel(first.mel, first.frames), meta: meta, contentKey: contentKey)
+            }
+            reader.pushBack(second)
+            return DecodedItem(file: file, kind: kind,
+                               payload: .audioSegments(mel: first.mel, frames: first.frames, reader: reader),
+                               meta: meta, contentKey: contentKey)
         }
         let content = (try? FileExtractor.extract(file.url, maxImageDimension: settings.maxImageDimension, maxVideoFrames: settings.maxVideoFrames)) ?? .empty
         switch content {
@@ -994,7 +1014,7 @@ public final class Indexer: @unchecked Sendable {
         case .text:  fp = "c\(settings.maxCharsPerChunk)|o\(chunkOverlap)|d\(settings.maxImageDimension)"   // d: scanned-PDF render size
         case .image: fp = "d\(settings.maxImageDimension)"
         case .video: fp = "d\(settings.maxImageDimension)|f\(settings.maxVideoFrames)"
-        case .audio: fp = ""
+        case .audio: fp = "s\(OmniAudioPreprocess.segmentMelFrames)"   // segmenting changes long-audio chunking
         }
         return "1|\(category.rawValue)|\(ext)|m\(embedder.dim)|\(fp)|\(digest)"
     }
@@ -1096,7 +1116,58 @@ public final class Indexer: @unchecked Sendable {
             return out
         case .pdfScan(let pageCount, let maxDimension):
             return embedScannedPDF(file: file, kind: kind, pageCount: pageCount, maxDimension: maxDimension)
+        case .audioSegments(let mel, let frames, let reader):
+            return embedStreamedAudio(file: file, kind: kind, firstMel: mel, firstFrames: frames,
+                                      reader: reader, duration: meta.duration)
         }
+    }
+
+    /// Stream-embed audio of ANY length: one embedding per 240 s segment, decoding the NEXT
+    /// segment on a background queue while the GPU embeds the current one - the audio twin of
+    /// embedScannedPDF. Peak memory is two segments (~30 MB) regardless of duration; the old
+    /// design allocated the whole file's PCM up front, which both overflowed AudioToolbox's
+    /// 32-bit byte count on multi-hour files (issue #7) and would have fed the backbone an
+    /// unbounded sequence. Chunks carry start-timestamp locators ("12:00").
+    func embedStreamedAudio(file: CrawledFile, kind: String, firstMel: [Float], firstFrames: Int,
+                            reader: OmniAudioPreprocess.AudioSegmentReader, duration: Double) -> [IndexedChunk] {   // internal for tests
+        // Reader calls are sequenced (the loop waits for the prefetch before starting the next
+        // one), so `reader` is only ever used by one thread at a time.
+        final class Box: @unchecked Sendable { var next: (mel: [Float], frames: Int)? }
+        let prefetchQ = DispatchQueue(label: "omni.indexer.audio-prefetch")
+        var out: [IndexedChunk] = []
+        var current: (mel: [Float], frames: Int)? = (firstMel, firstFrames)
+        var exhausted = false
+        var seg = 0
+        func locator(_ index: Int) -> String {
+            let s = Int(Double(index) * OmniAudioPreprocess.segmentSeconds)
+            return s >= 3600 ? String(format: "%d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60)
+                             : String(format: "%d:%02d", s / 60, s % 60)
+        }
+        while let cur = current {
+            // Cancel contract: never return a partial chunk set (it would be stored under the
+            // file's current mtime and silently truncate it forever) - same as embedScannedPDF.
+            if isCancelled { return [] }
+            let box = Box()
+            let sync = DispatchGroup()
+            if !exhausted {
+                sync.enter()
+                prefetchQ.async { box.next = reader.nextMelSegment(); sync.leave() }
+            }
+            if cur.frames > 0 {   // frames == 0: tail too short for the tower - skip the segment
+                guard let vec = embedder.embedAudioMel(cur.mel, frames: cur.frames) else {
+                    sync.wait()
+                    return []   // audio path unavailable: nothing to index
+                }
+                out.append(IndexedChunk(path: file.url.path, modified: file.modified, size: file.size,
+                                        kind: kind, chunkIndex: seg, snippet: file.url.lastPathComponent,
+                                        embedding: vec, duration: duration, locator: locator(seg)))
+            }
+            sync.wait()
+            current = box.next
+            if current == nil { exhausted = true }
+            seg += 1
+        }
+        return out
     }
 
     /// Stream-embed a scanned PDF of ANY length: rasterize + patchify `scanPageGroup` pages at a

--- a/Sources/OmniKit/OmniAudioPreprocess.swift
+++ b/Sources/OmniKit/OmniAudioPreprocess.swift
@@ -70,11 +70,27 @@ public enum OmniAudioPreprocess {
         return sinM
     }()
 
+    /// Mel frames per long-audio segment: 24000 frames = 240 s. Matches the indexer's audio
+    /// frame budget, so one segment fills exactly one batched-forward budget; the backbone cost
+    /// of a segment is the same as the longest clip the budget already allowed.
+    public static let segmentMelFrames = 24000
+    /// Seconds of audio per segment (240.0).
+    public static var segmentSeconds: Double { Double(segmentMelFrames) * Double(hop) / sampleRate }
+
     /// Decode + log-mel as a plain Float buffer (mel-major `[128*frames]`) + frame count.
     /// CPU-only and Sendable, so it can run in the concurrent decode stage of indexing.
+    /// Capped at ONE segment (240 s): a whole-file decode of a multi-hour file overflows
+    /// AudioToolbox's 32-bit byte count (issue #7) and its mel would feed the backbone an
+    /// O(L^2) sequence no machine survives. Files at or under the cap are byte-identical to
+    /// the old whole-file path; longer audio streams segment by segment via AudioSegmentReader.
     public static func melFeatures(url: URL) -> (mel: [Float], frames: Int)? {
-        guard let samples = decodeMono16k(url: url), !samples.isEmpty else { return nil }
+        guard let reader = AudioSegmentReader(url: url), let samples = reader.nextSegment() else { return nil }
+        return melFrom(samples: samples)
+    }
 
+    /// Log-mel of already-decoded 16 kHz mono samples (mel-major `[128*frames]`).
+    static func melFrom(samples: [Float]) -> (mel: [Float], frames: Int)? {
+        guard !samples.isEmpty else { return nil }
         let nBins = nFFT / 2 + 1   // 201
         let power = stftPower(samples)                  // [nBins, frames] row-major
         let frames = power.count / nBins
@@ -133,36 +149,86 @@ public enum OmniAudioPreprocess {
 
     // MARK: - Decode
 
-    /// Decode any audio file to 16 kHz mono Float32 PCM. Reads at the file's native
-    /// float32 processing format, downmixes to mono, and linearly resamples to 16 kHz.
-    /// Avoids AVAudioConverter (whose single-shot streaming is brittle for same-rate
-    /// passthrough) for a robust, dependency-free path.
-    private static func decodeMono16k(url: URL) -> [Float]? {
-        guard let file = try? AVAudioFile(forReading: url) else { return nil }
-        let fmt = file.processingFormat
-        let frameCount = AVAudioFrameCount(file.length)
-        guard frameCount > 0,
-              let buf = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: frameCount)
-        else { return nil }
-        do { try file.read(into: buf) } catch { return nil }
+    /// Sequential decoder: any audio file -> 16 kHz mono Float32 PCM, one bounded segment
+    /// (240 s) at a time. Reads the file's native float32 processing format in <= 60 s slices
+    /// into ONE reusable buffer, downmixes each slice to mono, and linearly resamples per
+    /// segment. Never sizes a buffer by the file's length: the old whole-file
+    /// `AVAudioPCMBuffer(frameCapacity: file.length)` made AudioToolbox compute
+    /// `frames x bytesPerFrame` in 32 bits, which throws an uncatchable C++ exception past
+    /// ~4.29 GB (a >= ~3 h 23 m stereo 44.1 kHz file) and aborted the whole scan - issue #7.
+    /// Slice reads are bounded regardless of file length, so the overflow is structurally
+    /// impossible. Avoids AVAudioConverter (whose single-shot streaming is brittle for
+    /// same-rate passthrough): sequential AVAudioFile reads concatenate to exactly the bytes
+    /// one whole-file read returns, so a file that fits in one segment decodes byte-identical
+    /// to the old path. Single-consumer; calls must be sequenced (the indexer's prefetch
+    /// queue does this, mirroring the scanned-PDF reader).
+    public final class AudioSegmentReader: @unchecked Sendable {
+        private let file: AVAudioFile
+        private let slice: AVAudioPCMBuffer
+        private let channelCount: Int
+        private let nativeRate: Double
+        private let nativeSegmentFrames: Int   // native frames per 240 s segment
+        private var done = false
 
-        let n = Int(buf.frameLength)
-        guard n > 0, let chans = buf.floatChannelData else { return nil }
-        let channelCount = Int(fmt.channelCount)
-
-        // Downmix to mono.
-        var mono = [Float](repeating: 0, count: n)
-        for c in 0 ..< channelCount {
-            let p = chans[c]
-            for i in 0 ..< n { mono[i] += p[i] }
+        public init?(url: URL) {
+            guard let f = try? AVAudioFile(forReading: url) else { return nil }
+            let fmt = f.processingFormat
+            guard fmt.sampleRate > 0, fmt.channelCount > 0, f.length > 0 else { return nil }
+            // <= 60 s of native audio per read, additionally capped in frames so an exotic
+            // high-rate/many-channel format stays far from any 32-bit byte limit.
+            let sliceFrames = AVAudioFrameCount(Swift.min(60.0 * fmt.sampleRate, 8_000_000))
+            guard sliceFrames > 0, let b = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: sliceFrames) else { return nil }
+            file = f
+            slice = b
+            channelCount = Int(fmt.channelCount)
+            nativeRate = fmt.sampleRate
+            nativeSegmentFrames = Int(OmniAudioPreprocess.segmentSeconds * fmt.sampleRate)
         }
-        if channelCount > 1 {
-            let inv = 1.0 / Float(channelCount)
-            for i in 0 ..< n { mono[i] *= inv }
+
+        /// The next segment as 16 kHz mono samples; nil at end of file.
+        public func nextSegment() -> [Float]? {
+            if done { return nil }
+            var mono: [Float] = []
+            mono.reserveCapacity(Swift.min(nativeSegmentFrames, 4_000_000))
+            while mono.count < nativeSegmentFrames {
+                let want = AVAudioFrameCount(Swift.min(Int(slice.frameCapacity), nativeSegmentFrames - mono.count))
+                slice.frameLength = 0
+                do { try file.read(into: slice, frameCount: want) } catch { done = true; break }
+                let n = Int(slice.frameLength)
+                if n == 0 { done = true; break }   // end of file
+                guard let chans = slice.floatChannelData else { done = true; break }
+                let base = mono.count
+                mono.append(contentsOf: repeatElement(0, count: n))
+                mono.withUnsafeMutableBufferPointer { m in
+                    for c in 0 ..< channelCount {
+                        let p = chans[c]
+                        for i in 0 ..< n { m[base + i] += p[i] }
+                    }
+                    if channelCount > 1 {
+                        let inv = 1.0 / Float(channelCount)
+                        for i in 0 ..< n { m[base + i] *= inv }
+                    }
+                }
+            }
+            if mono.isEmpty { return nil }
+            if abs(nativeRate - OmniAudioPreprocess.sampleRate) < 0.5 { return mono }
+            return OmniAudioPreprocess.resampleLinear(mono, from: nativeRate, to: OmniAudioPreprocess.sampleRate)
         }
 
-        if abs(fmt.sampleRate - sampleRate) < 0.5 { return mono }
-        return resampleLinear(mono, from: fmt.sampleRate, to: sampleRate)
+        /// The next segment's log-mel features; nil at end of file. Segments too short to
+        /// survive the tower (< 3 mel frames, < ~30 ms tail) come back as `([], 0)` so the
+        /// caller can skip the segment without mistaking it for end-of-file.
+        public func nextMelSegment() -> (mel: [Float], frames: Int)? {
+            if let p = pending { pending = nil; return p }
+            guard let samples = nextSegment() else { return nil }
+            return OmniAudioPreprocess.melFrom(samples: samples) ?? ([], 0)
+        }
+
+        /// Hand a segment back so the next `nextMelSegment()` returns it again. The indexer's
+        /// decode stage peeks one segment ahead to tell single-segment files (the common case,
+        /// which keeps the batched path) from long ones, then returns the peeked segment.
+        public func pushBack(_ segment: (mel: [Float], frames: Int)) { pending = segment }
+        private var pending: (mel: [Float], frames: Int)?
     }
 
     /// Linear-interpolation resample. Adequate for mel features; the embedding is robust.

--- a/Sources/omni-verify/main.swift
+++ b/Sources/omni-verify/main.swift
@@ -4,6 +4,7 @@ import ImageIO
 import CoreGraphics
 import MLX
 import Accelerate
+@preconcurrency import AVFoundation
 
 // Numeric validation of the MLX-Swift text encoder against Python reference fixtures.
 // Usage: omni-verify <modelDir> <fixturesJson>
@@ -1362,6 +1363,145 @@ if args.count >= 4 && args[1] == "dedupbench" {
     print("touched \(touchAll(target)) files (mtime bump, content unchanged)")
     await pass("touch ", force: false)
     exit(0)
+}
+
+// Long-audio segmentation check: omni-verify audiosegcheck [modelDir]
+// Issue #7: a whole-file AVAudioPCMBuffer overflows AudioToolbox's 32-bit byte count for
+// >= ~3 h 23 m stereo 44.1 kHz (frames x channels x 4 >= 2^32), aborting the scan. Verifies the
+// streamed AudioSegmentReader: (1) byte-identical decode vs a one-shot whole-file read for a
+// short file; (2) correct 240 s segmentation of a 10-minute file; (3) a synthesized
+// OVER-THRESHOLD file (~3 h 23 m stereo 44.1 kHz, ~2.2 GB WAV) decodes segment by segment where
+// the old path died. With modelDir: also embeds the 10-minute file end to end through the
+// indexer's streaming path and checks per-segment chunks + timestamp locators.
+func audiosegcheckRun(_ modelDir: String?) async throws -> Int32 {
+    var fails = 0
+    func check(_ cond: Bool, _ msg: String) { print("  \(cond ? "ok  " : "FAIL") \(msg)"); if !cond { fails += 1 } }
+    var root = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("omni-audioseg-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+    try? FileManager.default.removeItem(at: root)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    // The crawler stores canonical paths (/private/var/...); resolve the temp root the same way
+    // or every stored-path comparison below fabricates a mismatch (same trap as churnbench).
+    if let rp = realpath(root.path, nil) { root = URL(fileURLWithPath: String(cString: rp), isDirectory: true); free(rp) }
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // Synthesize a WAV: `seconds` of a quiet sine at `rate`/`channels` (int16 on disk).
+    func writeWAV(_ name: String, seconds: Double, rate: Double, channels: AVAudioChannelCount) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        let settings: [String: Any] = [AVFormatIDKey: kAudioFormatLinearPCM, AVSampleRateKey: rate,
+                                       AVNumberOfChannelsKey: channels, AVLinearPCMBitDepthKey: 16,
+                                       AVLinearPCMIsFloatKey: false, AVLinearPCMIsBigEndianKey: false]
+        let file = try AVAudioFile(forWriting: url, settings: settings)
+        let fmt = file.processingFormat
+        let sliceFrames = AVAudioFrameCount(min(60.0 * rate, 4_000_000))
+        guard let buf = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: sliceFrames) else {
+            throw OmniError.store("buffer alloc failed")
+        }
+        var written = 0
+        let total = Int(seconds * rate)
+        var phase: Float = 0
+        let step = Float(2.0 * Double.pi * 220.0 / rate)
+        while written < total {
+            let n = min(Int(sliceFrames), total - written)
+            buf.frameLength = AVAudioFrameCount(n)
+            if let ch = buf.floatChannelData {
+                for i in 0 ..< n { ch[0][i] = 0.05 * sinf(phase); phase += step }
+                for c in 1 ..< Int(fmt.channelCount) { memcpy(ch[c], ch[0], n * 4) }
+            }
+            try file.write(from: buf)
+            written += n
+        }
+        return url
+    }
+
+    print("audiosegcheck  root=\(root.lastPathComponent)")
+
+    // (1) Short stereo 44.1 kHz file: streamed decode must equal a one-shot whole-file read.
+    let short = try writeWAV("short.wav", seconds: 30, rate: 44100, channels: 2)
+    let reader1 = OmniAudioPreprocess.AudioSegmentReader(url: short)
+    let streamed = reader1?.nextSegment()
+    check(reader1?.nextSegment() == nil, "30s file is exactly one segment")
+    // One-shot reference decode (the old path, safe at this size).
+    var reference: [Float]? = nil
+    if let f = try? AVAudioFile(forReading: short),
+       let b = AVAudioPCMBuffer(pcmFormat: f.processingFormat, frameCapacity: AVAudioFrameCount(f.length)) {
+        try? f.read(into: b)
+        let n = Int(b.frameLength)
+        if let ch = b.floatChannelData {
+            var mono = [Float](repeating: 0, count: n)
+            for c in 0 ..< Int(f.processingFormat.channelCount) { for i in 0 ..< n { mono[i] += ch[c][i] } }
+            for i in 0 ..< n { mono[i] *= 0.5 }
+            // Same resample the production path applies (44.1 kHz -> 16 kHz).
+            let outN = Int((Double(n) * 16000.0 / 44100.0).rounded())
+            var out = [Float](repeating: 0, count: outN)
+            let stepR = 44100.0 / 16000.0
+            for i in 0 ..< outN {
+                let pos = Double(i) * stepR
+                let i0 = Int(pos), frac = Float(pos - Double(i0))
+                let a = mono[min(i0, n - 1)], bb = mono[min(i0 + 1, n - 1)]
+                out[i] = a + (bb - a) * frac
+            }
+            reference = out
+        }
+    }
+    check(streamed != nil && reference != nil && streamed! == reference!,
+          "streamed decode is byte-identical to the one-shot whole-file path (\(streamed?.count ?? -1) samples)")
+
+    // (2) 10-minute mono 16 kHz file: 240+240+120 second segments.
+    let tenMin = try writeWAV("tenmin.wav", seconds: 600, rate: 16000, channels: 1)
+    guard let reader2 = OmniAudioPreprocess.AudioSegmentReader(url: tenMin) else { print("  FAIL reader nil"); return 1 }
+    var segFrames: [Int] = []
+    while let seg = reader2.nextMelSegment() { segFrames.append(seg.frames) }
+    check(segFrames.count == 3, "10-minute file yields 3 segments (\(segFrames.count))")
+    check(segFrames.prefix(2).allSatisfy { $0 == OmniAudioPreprocess.segmentMelFrames },
+          "full segments carry \(OmniAudioPreprocess.segmentMelFrames) mel frames (\(segFrames))")
+    check(segFrames.last.map { $0 > 11_000 && $0 <= 12_000 } ?? false, "tail segment ~120s (\(segFrames.last ?? -1))")
+
+    // (3) Over the UInt32 threshold: stereo 44.1 kHz needs frames*2ch*4B >= 2^32, i.e.
+    // >= 536,870,912 frames = 12,174 s. The old whole-file alloc died here; streaming must not.
+    print("  writing ~2.2 GB over-threshold WAV (3h24m stereo 44.1kHz)...")
+    let long = try writeWAV("long.wav", seconds: 12_240, rate: 44100, channels: 2)
+    let sz = (try? FileManager.default.attributesOfItem(atPath: long.path)[.size] as? Int ?? 0) ?? 0
+    check(sz > 2_100_000_000, "over-threshold file written (\(sz / 1_000_000) MB)")
+    guard let reader3 = OmniAudioPreprocess.AudioSegmentReader(url: long) else {
+        print("  FAIL reader nil on over-threshold file"); return 1
+    }
+    var nSeg = 0
+    while reader3.nextSegment() != nil { nSeg += 1 }   // decode-only sweep over all 3.4 h
+    check(nSeg == 51, "over-threshold file decodes fully in segments (\(nSeg) of 51 expected)")
+
+    // (4) End-to-end with the real engine: stream-embed the 10-minute file, check locators.
+    if let modelDir {
+        let engine = try await OmniEngine.loadValidated(modelDir: URL(fileURLWithPath: modelDir))
+        if let probe = OmniAudioPreprocess.melFeatures(url: tenMin) {
+            let v = engine.embedAudioMel(probe.mel, frames: probe.frames)
+            check(v != nil && v!.allSatisfy { $0.isFinite }, "engine embeds one full \(probe.frames)-frame segment directly")
+        } else { check(false, "probe mel nil") }
+        let store = try VectorStore(dbURL: root.appendingPathComponent("index.sqlite"))
+        let indexer = Indexer(store: store, embedder: engine)
+        try? FileManager.default.removeItem(at: long)    // keep the e2e pass to the short files
+        let final: IndexProgress = await withCheckedContinuation { cont in
+            let once = NSLock(); var fired = false
+            indexer.index(roots: [root], settings: IndexSettings()) { p in
+                if p.done { once.lock(); let go = !fired; fired = true; once.unlock(); if go { cont.resume(returning: p) } }
+            }
+        }
+        check(final.failed == 0, "e2e pass clean (failed=\(final.failed))")
+        let hits = store.search(engine.embedText("a low quiet tone", as: .query), topK: 8)
+        let tenHit = hits.first { $0.path == tenMin.path }
+        check(tenHit != nil, "10-minute file is searchable")
+        check(tenHit?.chunkCount == 3, "10-minute file has 3 segment chunks (\(tenHit?.chunkCount ?? -1))")
+        let locators = Set(store.rankChunks(engine.embedText("tone", as: .query), path: tenMin.path).map { $0.locator })
+        check(locators == ["0:00", "4:00", "8:00"], "timestamp locators per segment (\(locators.sorted()))")
+        store.close()
+    } else {
+        print("  (no modelDir given - skipping the GPU e2e step)")
+    }
+
+    print("  RESULT: \(fails == 0 ? "PASS" : "FAIL (\(fails))")")
+    return fails == 0 ? 0 : 1
+}
+if args.count >= 2 && args[1] == "audiosegcheck" {
+    exit(try await audiosegcheckRun(args.count >= 3 ? args[2] : nil))
 }
 
 // Per-process NaN sweep: omni-verify nansweep <modelDir> [imageDir] [reps]


### PR DESCRIPTION
Fixes #7.

## Problem

`decodeMono16k` allocated one whole-file `AVAudioPCMBuffer` (`frameCapacity = file.length`). AudioToolbox sizes that buffer with a 32-bit checked multiply, so past ~4.29 GB (a >= ~3 h 23 m stereo 44.1 kHz file) it throws an uncatchable C++ exception: SIGABRT on 0.1.46, a silent scan halt on 0.1.50 - exactly as diagnosed in the issue. Independently, even a successful whole-file decode would feed the backbone an unbounded O(L^2) sequence for multi-hour audio.

## Fix

`AudioSegmentReader` replaces the whole-file decode: native-format reads in <= 60 s slices into one reusable buffer, downmixed and resampled per 240 s segment (24000 mel frames - the indexer's existing audio frame budget, so one segment costs what the longest previously-allowed clip already did). Buffer sizes are bounded by construction regardless of file length, so the UInt32 overflow is structurally impossible - no clamp/reject needed.

Long files now stream through the embed stage the same way scanned PDFs do: one embedding per segment, the next segment decoding on a background queue while the GPU embeds the current one, peak memory ~two segments regardless of duration. Segments carry start-time locators ("4:00", "1:20:00"), so a 5-hour recording becomes fully searchable instead of crashing the scan.

Files within one segment - the common case - keep the exact old path: sequential slice reads concatenate to the same bytes as the one-shot read, so the mel is byte-identical and the cross-file audio batching is untouched.

## Verification

New `omni-verify audiosegcheck` (runs the GPU end-to-end when given a model dir):

- streamed decode of a 30 s stereo 44.1 kHz file is byte-identical to the one-shot whole-file path
- a 10-minute file segments as 240/240/120 s
- a synthesized **2.2 GB over-threshold WAV (3 h 24 m stereo 44.1 kHz)** decodes fully in 51 segments where the old code aborted
- end-to-end index of the 10-minute file yields 3 searchable chunks with locators `0:00 / 4:00 / 8:00`

Audio parity fixtures unchanged (0.99987 vs the Python reference); audiobench unchanged (43 ms/clip batch-N); full suite at its known baseline.

## Note on the video case

Long video frame sampling was audited and does not share this bug: `videoFrames` caps candidates at `maxFrames x 4` and uses seek-based image generation with no duration-scaled allocation. An audio-only container with a video extension never reaches the audio decode path either (it yields no frames and is skipped). If a long `.mp4` still halts a scan after this fix, that is a distinct bug and a sample file would help.