### PR TITLE
photos: index the resident derivative, like the file pipeline does

### DIFF
--- a/Sources/OmniKit/Indexer.swift
+++ b/Sources/OmniKit/Indexer.swift
@@ -1709,9 +1709,19 @@ public final class Indexer: @unchecked Sendable {
 
         guard let image = PhotoLibrary.image(ref, maxDimension: settings.maxImageDimension,
                                              allowNetwork: allowNetwork) else { return DecodedItem(file: file) }
-        // The decoded size is the truth about what the tower will see; PHAsset's pixel dimensions
-        // describe the original, which for an edited photo is a different picture.
-        meta = (image.width, image.height, 0)
+        // A row's width/height is the asset's OWN resolution, the same quality signal a file row
+        // carries (the file path stores the original's pixel size, not the downscaled decode).
+        // The decode is normally a pure downscale to maxImageDimension, and under Optimize Mac
+        // Storage it can be a smaller resident derivative still - reporting either as the photo's
+        // size would tell the UI and the serving layer that a 4000 px photo is a 1024 px one.
+        //
+        // The exception is an EDIT: a crop changes the framing, so the decoded aspect ratio stops
+        // matching the asset's and the decoded numbers are the ones describing the real picture.
+        let assetAR = info.height > 0 ? Double(info.width) / Double(info.height) : 0
+        let decodedAR = image.height > 0 ? Double(image.width) / Double(image.height) : 0
+        let sameFraming = assetAR > 0 && decodedAR > 0 && abs(assetAR - decodedAR) <= 0.01 * assetAR
+        meta = sameFraming ? (max(info.width, image.width), max(info.height, image.height), 0)
+                           : (image.width, image.height, 0)
         let item = DecodedItem(file: file, kind: kind,
                                payload: .imagePatches([OmniVisionPreprocess.preprocessRaw(image)]),
                                meta: meta, contentKey: contentKey)

--- a/Sources/OmniKit/PhotosSource.swift
+++ b/Sources/OmniKit/PhotosSource.swift
@@ -238,9 +238,15 @@ public enum PhotoLibrary {
         public let height: Int
         public let duration: Double
         public let isVideo: Bool
-        /// Is the asset's content on this Mac? False for an iCloud-only ("Optimize Mac Storage")
-        /// asset, whose bytes would have to be DOWNLOADED to be embedded - the Photos twin of a
-        /// dataless file, and gated by the same setting.
+        /// Is SOME renderable version of this asset on this Mac? True when Photos can produce an
+        /// image with the network off, whether that is the full-size original or the downscaled
+        /// derivative that "Optimize Mac Storage" leaves resident. False only for an asset with
+        /// nothing local at all, which is the true twin of a dataless file.
+        ///
+        /// The distinction matters because the embedding is computed from a <= maxImageDimension
+        /// resize either way: a resident preview is usually ALREADY above that, so it produces the
+        /// same vectors the original would. Gating on "is the original here" instead skipped a
+        /// whole optimized library that Omni could read without a single byte of download.
         public let isLocal: Bool
     }
 
@@ -264,6 +270,12 @@ public enum PhotoLibrary {
     /// for the smallest possible image with the network SHUT OFF: `PHImageResultIsInCloudKey` is
     /// set exactly when the request would have needed a download. Cheap (a cached thumbnail read),
     /// and honest - deriving it from resource flags misses the optimized-storage case.
+    ///
+    /// `.fastFormat` is deliberate and is what makes this the RIGHT question: it accepts a degraded
+    /// answer, so it succeeds for any asset with a resident derivative and fails only when there is
+    /// genuinely nothing to read without a download. It must stay in step with the delivery mode
+    /// `image(_:maxDimension:allowNetwork:)` uses - a probe more permissive than the decode would
+    /// wave through assets that then embed as nil, which is how #13 produced skipped photos.
     private static func isLocal(_ asset: PHAsset) -> Bool {
         let opts = PHImageRequestOptions()
         opts.isSynchronous = true
@@ -278,11 +290,22 @@ public enum PhotoLibrary {
         return local
     }
 
+    /// The long edge to ask PhotoKit for: `maxDimension`, but never more than the asset already
+    /// has. `.exact` delivers the size it is asked for, so requesting 1568 for a 640 px asset
+    /// would hand back an upscaled 1568 px image - more vision tokens carrying no more information.
+    /// The file pipeline cannot do this (`kCGImageSourceThumbnailMaxPixelSize` is a cap, never an
+    /// enlargement), so capping here is what keeps the two paths producing the same embedding for
+    /// the same picture. Pure, so it is unit-testable without a photo library.
+    static func targetSide(maxDimension: Int, pixelWidth: Int, pixelHeight: Int) -> Int {
+        let cap = max(64, maxDimension)
+        let longest = max(pixelWidth, pixelHeight)
+        return longest > 0 ? min(cap, longest) : cap
+    }
+
     /// A decoded still, no larger than `maxDimension` on its long edge.
     ///
     /// `allowNetwork == false` is the default posture: it keeps an index pass from silently pulling
-    /// a library down from iCloud, and costs nothing in quality - Photos keeps a local derivative
-    /// well above the 1568 px the vision tower resizes to anyway.
+    /// a library down from iCloud.
     public static func image(_ ref: Ref, maxDimension: Int, allowNetwork: Bool) -> CGImage? {
         guard let a = asset(ref) else { return nil }
         return image(a, maxDimension: maxDimension, allowNetwork: allowNetwork)
@@ -291,17 +314,27 @@ public enum PhotoLibrary {
     private static func image(_ asset: PHAsset, maxDimension: Int, allowNetwork: Bool) -> CGImage? {
         let opts = PHImageRequestOptions()
         opts.isSynchronous = true          // called from the indexer's decode stage / a detached task
-        opts.deliveryMode = .highQualityFormat
+        // THE SAME CONTRACT THE FILE PIPELINE HAS: "the best representation available here, capped
+        // at maxDimension" - never "this exact size or nothing". `.highQualityFormat` is the second
+        // one: it promises a result "as asked or better", so with the network off it has to REFUSE
+        // an asset whose only local copy is a smaller derivative, and returns nil. Under Optimize
+        // Mac Storage that is nearly the whole library - the user in #13 had 40 GB of resident
+        // previews for 40,000 photos and got about 150 of them indexed.
+        //
+        // `.opportunistic` with isSynchronous is documented to deliver exactly one result, the best
+        // it can do under the other options - the local derivative when that is all there is, the
+        // full-size render when the asset is materialized. That is what FileExtractor.loadImage
+        // already does for a file on disk, and a 1024 px embedding of a photo beats no row for it.
+        opts.deliveryMode = .opportunistic
         // .exact, NOT .fast: `.fast` is documented to answer with a size merely CLOSE to the target,
-        // which it is free to satisfy from a cached derivative smaller than what was asked for -
-        // and an image the tower sees at less than maxImageDimension is a quietly worse embedding
-        // than the same picture would get as a file on disk. `.exact` costs one resize of an image
-        // the preprocess is about to resize anyway, which is nothing beside the vision forward.
+        // so it can overshoot into a needlessly large decode. The target is capped to the asset's
+        // own pixels (see targetSide), so exact never means upscaled.
         opts.resizeMode = .exact
         opts.isNetworkAccessAllowed = allowNetwork
         opts.version = .current            // the photo as the user edited it, not the original
         var out: CGImage?
-        let side = CGFloat(max(64, maxDimension))
+        let side = CGFloat(targetSide(maxDimension: maxDimension,
+                                      pixelWidth: asset.pixelWidth, pixelHeight: asset.pixelHeight))
         PHImageManager.default().requestImage(for: asset, targetSize: CGSize(width: side, height: side),
                                               contentMode: .aspectFit, options: opts) { image, _ in
             guard let image else { return }
@@ -319,7 +352,12 @@ public enum PhotoLibrary {
     public static func video(_ ref: Ref, allowNetwork: Bool) -> AVAsset? {
         guard let a = asset(ref), a.mediaType == .video else { return nil }
         let opts = PHVideoRequestOptions()
-        opts.deliveryMode = .highQualityFormat
+        // `.automatic` for the same reason `image` uses `.opportunistic`: take the best local
+        // representation rather than insist on the top one. PhotoKit documents automatic as
+        // defaulting to the high-quality format whenever the video IS locally available, so a
+        // materialized clip is sampled exactly as before; an optimized-storage one now yields its
+        // resident derivative instead of nothing.
+        opts.deliveryMode = .automatic
         opts.isNetworkAccessAllowed = allowNetwork
         opts.version = .current
         // No synchronous form exists for video; the decode stage is already off the main thread.

--- a/Tests/OmniKitTests/PhotoTargetSizeTests.swift
+++ b/Tests/OmniKitTests/PhotoTargetSizeTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import CoreGraphics
+@testable import OmniKit
+
+/// The Photos decode has to reduce exactly like the file decode does. `FileExtractor.loadImage`
+/// passes `kCGImageSourceThumbnailMaxPixelSize`, which is a CAP: a smaller image comes back at its
+/// own size and is never enlarged. PhotoKit's `.exact` resize has no such property - it delivers
+/// the size it is asked for - so the target has to be clamped to the asset before the request.
+///
+/// These pin the pure part of that (no photo library, no authorization needed).
+final class PhotoTargetSizeTests: XCTestCase {
+
+    /// A big asset is capped at the setting, exactly like a big file.
+    func testLargeAssetIsCappedAtMaxDimension() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 4032, pixelHeight: 3024), 1568)
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 3024, pixelHeight: 4032), 1568)
+    }
+
+    /// THE REGRESSION: a small asset must keep its own size. Asking `.exact` for 1568 here would
+    /// hand back an upscaled image - more vision tokens carrying no more information, and a
+    /// different embedding than the same picture would get as a file on disk.
+    func testSmallAssetIsNotUpscaled() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 640, pixelHeight: 480), 640)
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 100, pixelHeight: 900), 900)
+    }
+
+    /// The long edge decides, for either orientation - the same thing `contentMode: .aspectFit`
+    /// with a square target means.
+    func testLongEdgeDecides() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1000, pixelWidth: 1200, pixelHeight: 300), 1000)
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1000, pixelWidth: 300, pixelHeight: 1200), 1000)
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 2000, pixelWidth: 1200, pixelHeight: 300), 1200)
+    }
+
+    /// An asset that reports no dimensions (PhotoKit occasionally has none for a placeholder) must
+    /// not collapse the request to zero; fall back to the cap and let PhotoKit answer.
+    func testMissingAssetDimensionsFallBackToTheCap() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 0, pixelHeight: 0), 1568)
+    }
+
+    /// The 64 px floor of the old code is preserved, including for a nonsense setting.
+    func testFloorHolds() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 0, pixelWidth: 4032, pixelHeight: 3024), 64)
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: -5, pixelWidth: 4032, pixelHeight: 3024), 64)
+    }
+
+    /// A tiny asset under the floor still asks for its own size, not the floor: the clamp is
+    /// min(cap, longest), and 32 < 64.
+    func testTinyAssetAsksForItsOwnSize() {
+        XCTAssertEqual(PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: 32, pixelHeight: 32), 32)
+    }
+}


### PR DESCRIPTION
Fixes #13.

## Root cause

The two ingestion paths were asking PhotoKit and CoreGraphics *different questions* for the same job.

The file path asks for a **cap**:

\`\`\`swift
// FileExtractor.loadImage
kCGImageSourceThumbnailMaxPixelSize: maxDimension   // best available, no larger than this
\`\`\`

The Photos path asked for a **floor**:

\`\`\`swift
// PhotosSource.image
opts.deliveryMode = .highQualityFormat   // "as asked or better"
\`\`\`

`.highQualityFormat` is documented as *"client will get one result only and it will be as asked or better than asked"*. With `isNetworkAccessAllowed = false`, that is a promise PhotoKit cannot keep for an asset whose only local copy is a downscaled derivative, so it returns nil and the indexer skips the asset.

Under **Optimize Mac Storage** that describes nearly the entire library. The reporter has 40,000 photos and 40 GB of resident previews, and gets about 150 rows.

`isLocal` was not the bug: it probes with `.fastFormat`, which accepts a degraded answer, so it correctly reported these assets as local. The decode then refused what the probe had waved through.

## Fix

Ask the same question the file pipeline asks.

- **Stills**: `.opportunistic`, which combined with `isSynchronous` is documented to deliver exactly one result, the best available under the other options. Full-size render when the asset is materialized, resident derivative when it is not.
- **Video**: `.highQualityFormat` to `.automatic`, which PhotoKit defines as defaulting to the high-quality format *whenever the video is locally available* - so a materialized clip is sampled exactly as before.

Embedding quality is not the tradeoff it looks like. The vectors come from a resize to `maxImageDimension` (1568) regardless of source, and a resident preview is normally already larger than that, so it yields the vectors the original would. Where it is smaller, a 1024 px embedding of a photo still beats having no row for it.

## Two consequences, both handled

**1. `.exact` upscales.** Unlike the CoreGraphics cap, `.exact` delivers the size it is asked for, so a 640 px asset asked for 1568 comes back enlarged - more vision tokens carrying no more information, and a different embedding than the same picture gets as a file on disk. New pure helper clamps the request to the asset:

\`\`\`swift
static func targetSide(maxDimension: Int, pixelWidth: Int, pixelHeight: Int) -> Int {
    let cap = max(64, maxDimension)
    let longest = max(pixelWidth, pixelHeight)
    return longest > 0 ? min(cap, longest) : cap
}
\`\`\`

**2. Row dimensions are a quality signal, not a decode artifact.** The file path stores the original resolution, not the downscaled frame fed to the encoder. Now that the Photos decode may legitimately be a small derivative, reporting its size would tell the UI and the serving layer that a 4000 px photo is a 1024 px one. `decodePhoto` keeps the asset dimensions, falling back to the decoded ones when the aspect ratio differs by >1% - the case where an edit (a crop) means the asset numbers no longer describe the real picture.

## Verification

- `Tests/OmniKitTests/PhotoTargetSizeTests.swift`, 6 new tests covering the cap, the no-upscale regression, both orientations, missing dimensions, the 64 px floor, and a sub-floor asset. No photo library or authorization needed.
- Full suite: **192 tests, 0 failures** (15 skipped - they need the model dir).
- `./Scripts/build-app.sh Debug` - BUILD SUCCEEDED.

## Note on the broader pattern

This bug is what pipeline divergence looks like: a second ingestion channel reimplementing "load an image, downscaled" with subtly different semantics from the first. `targetSide` exists so the Photos path now has the CoreGraphics cap property explicitly, rather than by accident. Worth keeping in mind for future ingestion sources (external disks, special folders) - they should reuse the extractor contract rather than restate it.