### PR TITLE
indexer: one decode path behind a ContentSource protocol

### DIFF
--- a/Sources/OmniKit/ContentSource.swift
+++ b/Sources/OmniKit/ContentSource.swift
@@ -1,0 +1,259 @@
+import Foundation
+import CoreGraphics
+import AVFoundation
+
+/// What a source knows about an item BEFORE its content is decoded: which tower will embed it, and
+/// the dimensions/duration describing the ORIGINAL - not whatever the decode happens to hand back.
+struct SourceProbe: Sendable {
+    let kind: FileKind
+    let width: Int
+    let height: Int
+    let duration: Double
+    /// Did the source actually READ the item's metrics? False when the header could not be parsed,
+    /// and for text, where there are none. Index-time minimums are skipped when this is false: a
+    /// file whose dimensions could not be determined has never been held to a threshold, and
+    /// starting now would silently drop it.
+    let measured: Bool
+
+    init(kind: FileKind, width: Int = 0, height: Int = 0, duration: Double = 0, measured: Bool = false) {
+        self.kind = kind; self.width = width; self.height = height
+        self.duration = duration; self.measured = measured
+    }
+
+    var meta: (width: Int, height: Int, duration: Double) { (width, height, duration) }
+}
+
+/// A decoded media payload plus the metadata the decode refined (an edited video's real duration,
+/// a cropped photo's real framing). Returned by the source; the indexer stores it as-is.
+struct SourceDecode {
+    let payload: DecodedItem.Payload
+    let meta: (width: Int, height: Int, duration: Double)
+
+    init(payload: DecodedItem.Payload, meta: (width: Int, height: Int, duration: Double)) {
+        self.payload = payload; self.meta = meta
+    }
+}
+
+/// ONE INGESTION CHANNEL: where items come from and how their bytes are reached.
+///
+/// A source answers only source-specific questions - can this be read without a download, how big
+/// is it, give me its content. Everything that is POLICY rather than plumbing (which thresholds
+/// apply, when content dedup short-circuits, how a payload becomes chunks, the byte budget, the
+/// HQ-tag crops) lives once in `Indexer.decode` and is therefore identical for every source by
+/// construction.
+///
+/// This split exists because it was violated. The Photos channel arrived as a parallel
+/// `decodePhoto` that restated all of that policy, and the restatement drifted: it asked PhotoKit
+/// for `.highQualityFormat` ("as asked or better") where the file path asks CoreGraphics for a CAP
+/// ("best available, no larger than"). With the network off PhotoKit cannot promise "or better" for
+/// an optimized-storage asset, so it returned nil and ~40,000 photos indexed as ~150 (issue #13).
+/// A new channel - an external disk, a special folder, a mail store - implements this protocol and
+/// inherits the policy instead of copying it.
+///
+/// Sources are stateless values created per decode call; anything expensive belongs in a cache
+/// inside the source's own type (see `PhotoLibrary`'s filename cache).
+protocol ContentSource: Sendable {
+    /// Does this source own the item? Exactly one source claims any given path.
+    static func claims(_ file: CrawledFile) -> Bool
+
+    /// Kind and original dimensions, WITHOUT decoding the content.
+    ///
+    /// Nil means "produce nothing for this item, right now" and covers every such case at once:
+    /// gone from the library, and content that could only be reached by an implicit network
+    /// download (a cloud-evicted file, an iCloud-only asset) under `skipDataless`. Nil is NOT a
+    /// deletion - the crawl still marks the item seen, so the stale sweep never drops its rows, and
+    /// it indexes normally once materialized.
+    ///
+    /// One call, because for some sources readability and metrics are the same expensive question:
+    /// PhotoKit answers both from a single `PhotoLibrary.info`, and asking twice per asset is
+    /// measurable across a six-figure library.
+    func probe(_ file: CrawledFile, settings: IndexSettings) -> SourceProbe?
+
+    /// Identity of the bytes that determine this item's embedding, or nil if it cannot be had
+    /// cheaply. Two items with equal keys MUST embed identically - the indexer copies stored rows
+    /// on a hit rather than running the towers, so anything that changes the vectors (preprocess
+    /// settings, model dimension) belongs in the key.
+    func contentKey(_ file: CrawledFile, kind: FileKind, dim: Int,
+                    chunkOverlap: Int, settings: IndexSettings) -> String?
+
+    /// Text, still images, or a scanned-PDF handle. The shared decode turns this into a payload.
+    func content(_ file: CrawledFile, kind: FileKind, settings: IndexSettings) -> ExtractedContent
+
+    /// Video: frames now, or a segment plan for the embed stage to sample lazily. Nil = unreadable.
+    func video(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode?
+
+    /// Audio: the first mel segment, plus the open reader when the item runs longer than one.
+    /// Nil = unreadable, or the source has no audio at all (a Photos asset is image or video).
+    func audio(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode?
+
+    /// The dimensions to STORE for a still, given what the probe said and what the decode produced.
+    /// Default: the probe's, because a row's size is a quality signal describing the original while
+    /// the decode is normally just a downscale to `maxImageDimension`.
+    func metaAfterImageDecode(probe: SourceProbe, decoded: CGImage) -> (width: Int, height: Int, duration: Double)
+}
+
+extension ContentSource {
+    func metaAfterImageDecode(probe: SourceProbe, decoded: CGImage) -> (width: Int, height: Int, duration: Double) {
+        probe.meta
+    }
+}
+
+// MARK: - Files on disk
+
+/// The original channel: anything with a real filesystem path.
+struct FileContentSource: ContentSource {
+    static func claims(_ file: CrawledFile) -> Bool { !file.isPhoto }
+
+    func probe(_ file: CrawledFile, settings: IndexSettings) -> SourceProbe? {
+        // A dataless (cloud-evicted) file: reading its body would implicitly DOWNLOAD it, so under
+        // the skip policy nothing here may touch its content. Checked FIRST, before any header
+        // read. An already-indexed file that was later evicted does not even reach here - eviction
+        // keeps mtime and size, so the unchanged check holds it and it stays searchable.
+        if settings.skipDataless, FileExtractor.isDataless(file.path) { return nil }
+        let kind = FileExtractor.kind(for: file.url) ?? .text
+        switch kind {
+        case .image:
+            guard let s = FileExtractor.imagePixelSize(file.url) else { return SourceProbe(kind: kind) }
+            return SourceProbe(kind: kind, width: s.width, height: s.height, measured: true)
+        case .video, .audio:
+            guard let info = FileExtractor.mediaInfo(file.url) else { return SourceProbe(kind: kind) }
+            // Media rows carry the file's ORIGINAL resolution (a quality signal for the serving
+            // layer), not the downscaled frame size fed to the encoder.
+            return SourceProbe(kind: kind, width: info.width, height: info.height,
+                               duration: info.duration, measured: true)
+        case .text, .scan:   // .scan never comes from detection (extraction-time only)
+            return SourceProbe(kind: kind)
+        }
+    }
+
+    func contentKey(_ file: CrawledFile, kind: FileKind, dim: Int,
+                    chunkOverlap: Int, settings: IndexSettings) -> String? {
+        Indexer.fileContentKey(file, category: kind, dim: dim, chunkOverlap: chunkOverlap, settings: settings)
+    }
+
+    func content(_ file: CrawledFile, kind: FileKind, settings: IndexSettings) -> ExtractedContent {
+        (try? FileExtractor.extract(file.url, maxImageDimension: settings.maxImageDimension,
+                                    maxVideoFrames: settings.maxVideoFrames)) ?? .empty
+    }
+
+    func video(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode? {
+        // A video longer than one segment streams per 240 s window in the embed stage (one
+        // embedding + timestamp locator per window), mirroring long audio - a 3-hour recording
+        // becomes fully searchable instead of compressing into one start-biased vector. Frame
+        // extraction is stateless seeks, so the payload carries parameters only.
+        if probe.duration.isFinite, probe.duration > Indexer.mediaSegmentSeconds {
+            return SourceDecode(payload: .videoSegments(duration: probe.duration,
+                                                        maxFrames: settings.maxVideoFrames,
+                                                        maxDimension: settings.maxImageDimension),
+                                meta: probe.meta)
+        }
+        let frames = FileExtractor.videoFrames(file.url, maxFrames: settings.maxVideoFrames,
+                                               maxDimension: settings.maxImageDimension)
+        return frames.isEmpty ? nil : SourceDecode(payload: .images(frames), meta: probe.meta)
+    }
+
+    func audio(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode? {
+        // Stream-decode in bounded segments (issue #7: a whole-file PCM buffer for a multi-hour
+        // file overflows AudioToolbox's 32-bit byte count and killed the scan). One segment (the
+        // overwhelmingly common case, <= 240 s) keeps the exact single-shot .audioMel path -
+        // byte-identical mel, cross-file batching preserved. Longer files carry the open reader to
+        // the embed stage, which streams one embedding per segment.
+        guard let reader = OmniAudioPreprocess.AudioSegmentReader(url: file.url),
+              let first = reader.nextMelSegment(), first.frames > 0 else { return nil }
+        guard let second = reader.nextMelSegment() else {
+            return SourceDecode(payload: .audioMel(first.mel, first.frames), meta: probe.meta)
+        }
+        reader.pushBack(second)
+        return SourceDecode(payload: .audioSegments(mel: first.mel, frames: first.frames, reader: reader),
+                            meta: probe.meta)
+    }
+}
+
+// MARK: - The Apple Photos library
+
+/// Photos assets ride the same pipeline under `photos://` paths, which are NOT filesystem paths:
+/// every read the file source performs (stat, header, byte hash) would be asking the filesystem
+/// about something that does not exist there. PhotoKit answers all of it.
+struct PhotosContentSource: ContentSource {
+    let ref: PhotoLibrary.Ref
+
+    static func claims(_ file: CrawledFile) -> Bool { file.isPhoto }
+
+    func probe(_ file: CrawledFile, settings: IndexSettings) -> SourceProbe? {
+        guard let info = PhotoLibrary.info(ref) else { return nil }   // gone from the library
+        // AN ICLOUD-ONLY ASSET IS A DATALESS FILE and is gated by the same setting: embedding it
+        // would make an index pass silently pull the library down from iCloud. `isLocal` means some
+        // renderable version is HERE, including the downscaled derivative that Optimize Mac Storage
+        // leaves resident - that is what the decode can read, and the substance of issue #13.
+        guard info.isLocal || !settings.skipDataless else { return nil }
+        return SourceProbe(kind: info.isVideo ? .video : .image, width: info.width, height: info.height,
+                           duration: info.duration, measured: true)
+    }
+
+    /// Keyed on the ASSET rather than its bytes. This is what makes an asset in two selected albums
+    /// cost one forward pass: the second source's path arrives, finds the first's rows under the
+    /// same key, and stores them rewritten. Hashing bytes would mean materializing every asset just
+    /// to discover that.
+    func contentKey(_ file: CrawledFile, kind: FileKind, dim: Int,
+                    chunkOverlap: Int, settings: IndexSettings) -> String? {
+        let fp = kind == .image
+            ? "d\(settings.maxImageDimension)"
+            : "v2|d\(settings.maxImageDimension)|f\(settings.maxVideoFrames)|s\(Int(Indexer.mediaSegmentSeconds))"
+        return "2|photo|\(kind.rawValue)|m\(dim)|t\(file.modified)|s\(file.size)|\(fp)|\(ref.localIdentifier)"
+    }
+
+    func content(_ file: CrawledFile, kind: FileKind, settings: IndexSettings) -> ExtractedContent {
+        guard kind == .image,
+              let image = PhotoLibrary.image(ref, maxDimension: settings.maxImageDimension,
+                                             allowNetwork: !settings.skipDataless) else { return .empty }
+        return .images([image])
+    }
+
+    func video(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode? {
+        guard let asset = PhotoLibrary.video(ref, allowNetwork: !settings.skipDataless) else { return nil }
+        // The clip's real duration and dimensions, now that it is open - PHAsset's are the
+        // ORIGINAL's, and an edit (a trim, a slow-motion ramp) changes both.
+        var meta = probe.meta
+        if let mi = FileExtractor.mediaInfo(asset: asset), mi.duration > 0 {
+            meta = (mi.width > 0 ? mi.width : meta.width, mi.height > 0 ? mi.height : meta.height, mi.duration)
+        }
+        if meta.duration.isFinite, meta.duration > Indexer.mediaSegmentSeconds {
+            // The AVAsset itself rides to the embed stage rather than a path to re-open: for an
+            // edited or slow-motion clip PhotoKit hands back a composition, with no file behind it.
+            return SourceDecode(payload: .photoVideoSegments(asset: asset, duration: meta.duration,
+                                                             maxFrames: settings.maxVideoFrames,
+                                                             maxDimension: settings.maxImageDimension),
+                                meta: meta)
+        }
+        let frames = FileExtractor.videoFrames(asset: asset, maxFrames: settings.maxVideoFrames,
+                                               maxDimension: settings.maxImageDimension)
+        return frames.isEmpty ? nil : SourceDecode(payload: .images(frames), meta: meta)
+    }
+
+    /// The library holds images and videos only.
+    func audio(_ file: CrawledFile, probe: SourceProbe, settings: IndexSettings) -> SourceDecode? { nil }
+
+    /// Keep the asset's own resolution, the way a file row keeps the original's - except after an
+    /// EDIT: a crop changes the framing, so the decoded aspect ratio stops matching the asset's and
+    /// the decoded numbers become the ones describing the real picture.
+    func metaAfterImageDecode(probe: SourceProbe, decoded: CGImage) -> (width: Int, height: Int, duration: Double) {
+        let assetAR = probe.height > 0 ? Double(probe.width) / Double(probe.height) : 0
+        let decodedAR = decoded.height > 0 ? Double(decoded.width) / Double(decoded.height) : 0
+        let sameFraming = assetAR > 0 && decodedAR > 0 && abs(assetAR - decodedAR) <= 0.01 * assetAR
+        return sameFraming ? (max(probe.width, decoded.width), max(probe.height, decoded.height), 0)
+                           : (decoded.width, decoded.height, 0)
+    }
+}
+
+// MARK: - Resolution
+
+enum ContentSources {
+    /// The one source that owns this item. Ordered most specific first; the file source is the
+    /// fallback, so a new channel is added ABOVE it with a `claims` that recognizes its own paths.
+    static func source(for file: CrawledFile) -> any ContentSource {
+        if PhotosContentSource.claims(file), let ref = PhotoLibrary.Ref(file.path) {
+            return PhotosContentSource(ref: ref)
+        }
+        return FileContentSource()
+    }
+}

--- a/Sources/OmniKit/Indexer.swift
+++ b/Sources/OmniKit/Indexer.swift
@@ -1524,52 +1524,51 @@ public final class Indexer: @unchecked Sendable {
     /// CPU-only decode: extraction, thresholds, frame sampling, audio mel. No GPU/MLX.
     /// Also captures display metadata (pixel size / duration) here, on the concurrent stage, so the
     /// serial embed stage never re-opens the file header.
+    ///
+    /// ONE PATH FOR EVERY INGESTION CHANNEL. What is source-specific (can this be read, how big is
+    /// it, hand me its bytes) is behind `ContentSource`; everything below - thresholds, dedup,
+    /// payload shape, HQ crops - is policy, and lives here exactly once so a new channel cannot
+    /// quietly acquire its own version of it. That is precisely how issue #13 happened.
     private func decode(_ file: CrawledFile, settings: IndexSettings) -> DecodedItem {
-        // A Photos asset is not a file: every read below (stat, header, byte hash) would be asking
-        // the filesystem about a path that does not exist there. PhotoKit answers all of it.
-        if let ref = PhotoLibrary.Ref(file.path) { return decodePhoto(file, ref: ref, settings: settings) }
-        // Dataless (cloud-evicted) file under the skip policy: reading its body would implicitly
-        // DOWNLOAD it. Return an empty item BEFORE any content read - the consume stage counts it
-        // skipped, and tick() still marks it `seen`, so reconcile never mistakes it for deleted. An
-        // already-indexed file that got evicted does not even reach here (eviction keeps mtime/size,
-        // so the unchanged check holds it); when the user materializes the file, the FSEvents
-        // reconcile (or the next pass) indexes it normally.
-        if settings.skipDataless, FileExtractor.isDataless(file.path) { return DecodedItem(file: file) }
-        let category = FileExtractor.kind(for: file.url) ?? .text
-        let kind = category.rawValue
-        var meta: (width: Int, height: Int, duration: Double) = (0, 0, 0)
+        let source = ContentSources.source(for: file)
 
-        switch category {
-        case .image:
-            if let s = FileExtractor.imagePixelSize(file.url) {
-                meta = (s.width, s.height, 0)
-                if settings.minImageDimension > 0, max(s.width, s.height) < settings.minImageDimension {
+        // Nil probe = produce nothing for this item right now: it is gone, or its content could
+        // only be reached by an implicit download under `skipDataless`. Not a deletion - the
+        // consume stage counts it skipped and tick() still marks it `seen`, so reconcile never
+        // mistakes it for removed, and it indexes once the user materializes it.
+        guard let probe = source.probe(file, settings: settings) else { return DecodedItem(file: file) }
+        let category = probe.kind
+        let kind = category.rawValue
+        var meta = probe.meta
+
+        // Index-time minimums, applied only to metrics the source actually measured: an item whose
+        // header could not be parsed has never been held to a threshold.
+        if probe.measured {
+            switch category {
+            case .image:
+                if settings.minImageDimension > 0, max(probe.width, probe.height) < settings.minImageDimension {
                     return DecodedItem(file: file)
                 }
-            }
-        case .video, .audio:
-            if let info = FileExtractor.mediaInfo(file.url) {
-                // Video rows carry the file's ORIGINAL resolution (a quality signal for the
-                // serving layer), not the downscaled frame size fed to the encoder.
-                meta = (info.width, info.height, info.duration)
+            case .video, .audio:
                 let minS = category == .video ? settings.minVideoSeconds : settings.minAudioSeconds
-                if minS > 0, info.duration < minS { return DecodedItem(file: file) }
+                if minS > 0, probe.duration < minS { return DecodedItem(file: file) }
+            case .text, .scan:
+                break
             }
-        case .text, .scan:   // .scan never comes from detection (extraction-time only)
-            break
         }
 
-        // Content dedup: if the store already holds the chunks for these exact bytes (same
+        // Content dedup: if the store already holds the chunks for this exact content (same
         // preprocess settings, same model), reuse them - no decode, no GPU forward. Measured on
         // a real home-folder corpus: 16% of images, 9% of audio, 8% of video and 6% of text
         // files are byte-level duplicates of an already-indexed file; a touched-but-identical
         // file (git checkout, re-save without changes) otherwise re-embeds for nothing. The key
         // is recorded once the file's chunks land (see pipeline()), and reuse is exact by
-        // construction: same input bytes + same settings produce the same vectors, so copying
-        // the stored rows is the embedding, minus the work.
+        // construction: same input + same settings produce the same vectors, so copying the
+        // stored rows is the embedding, minus the work.
         var contentKey: String? = nil
         if Self.contentDedup, !settings.forceFreshEmbed {
-            contentKey = self.contentKey(file, category: category, settings: settings)
+            contentKey = source.contentKey(file, kind: category, dim: embedder.dim,
+                                           chunkOverlap: chunkOverlap, settings: settings)
             if let ck = contentKey, let src = store.duplicateChunks(key: ck) {
                 noteDedupHit()
                 return DecodedItem(file: file, kind: kind, payload: .duplicate(Self.rewrite(src, to: file)),
@@ -1578,39 +1577,15 @@ public final class Indexer: @unchecked Sendable {
         }
 
         if category == .video {
-            // A video longer than one segment streams per 240 s window in the embed stage
-            // (one embedding + timestamp locator per window), mirroring long audio - a 3-hour
-            // recording becomes fully searchable instead of compressing into one start-biased
-            // vector. Frame extraction is stateless seeks, so the payload carries parameters
-            // only. Videos within one segment keep the single-clip path.
-            if meta.duration.isFinite, meta.duration > Self.mediaSegmentSeconds {
-                return DecodedItem(file: file, kind: kind,
-                                   payload: .videoSegments(duration: meta.duration,
-                                                           maxFrames: settings.maxVideoFrames,
-                                                           maxDimension: settings.maxImageDimension),
-                                   meta: meta, contentKey: contentKey)
-            }
-            let frames = FileExtractor.videoFrames(file.url, maxFrames: settings.maxVideoFrames, maxDimension: settings.maxImageDimension)
-            return frames.isEmpty ? DecodedItem(file: file) : DecodedItem(file: file, kind: kind, payload: .images(frames), meta: meta, contentKey: contentKey)
+            guard let out = source.video(file, probe: probe, settings: settings) else { return DecodedItem(file: file) }
+            return DecodedItem(file: file, kind: kind, payload: out.payload, meta: out.meta, contentKey: contentKey)
         }
         if category == .audio {
-            // Stream-decode in bounded segments (issue #7: a whole-file PCM buffer for a
-            // multi-hour file overflows AudioToolbox's 32-bit byte count and killed the scan).
-            // One segment (the overwhelmingly common case, <= 240 s) keeps the exact old
-            // .audioMel path - byte-identical mel, cross-file batching preserved. Longer files
-            // carry the open reader to the embed stage, which streams one embedding per segment.
-            guard let reader = OmniAudioPreprocess.AudioSegmentReader(url: file.url),
-                  let first = reader.nextMelSegment(), first.frames > 0 else { return DecodedItem(file: file) }
-            guard let second = reader.nextMelSegment() else {
-                return DecodedItem(file: file, kind: kind, payload: .audioMel(first.mel, first.frames), meta: meta, contentKey: contentKey)
-            }
-            reader.pushBack(second)
-            return DecodedItem(file: file, kind: kind,
-                               payload: .audioSegments(mel: first.mel, frames: first.frames, reader: reader),
-                               meta: meta, contentKey: contentKey)
+            guard let out = source.audio(file, probe: probe, settings: settings) else { return DecodedItem(file: file) }
+            return DecodedItem(file: file, kind: kind, payload: out.payload, meta: out.meta, contentKey: contentKey)
         }
-        let content = (try? FileExtractor.extract(file.url, maxImageDimension: settings.maxImageDimension, maxVideoFrames: settings.maxVideoFrames)) ?? .empty
-        switch content {
+
+        switch source.content(file, kind: category, settings: settings) {
         case .empty:
             return DecodedItem(file: file)
         case .text(let text):
@@ -1628,6 +1603,12 @@ public final class Indexer: @unchecked Sendable {
                                payload: .pdfScan(pageCount: pageCount, maxDimension: settings.maxImageDimension), meta: meta, contentKey: contentKey)
         case .images(let images):
             if images.isEmpty { return DecodedItem(file: file) }
+            // The decode is normally a pure downscale, so the row keeps the ORIGINAL's dimensions
+            // (a quality signal for the UI and the serving layer). A source overrides this when its
+            // decode can legitimately reframe the picture - see PhotosContentSource on edits.
+            if let first = images.first, images.count == 1 {
+                meta = source.metaAfterImageDecode(probe: probe, decoded: first)
+            }
             // Still images: run the CPU preprocess (resize + parallel patchify) HERE, in the
             // concurrent decode stage, so the serialized GPU thread only does the tower.
             let raws = images.map { OmniVisionPreprocess.preprocessRaw($0) }
@@ -1644,105 +1625,17 @@ public final class Indexer: @unchecked Sendable {
         }
     }
 
-    /// The Photos twin of `decode`. Same shape - thresholds, content dedup, then a payload - with
-    /// PhotoKit standing in for every filesystem read.
-    ///
-    /// AN ICLOUD-ONLY ASSET IS A DATALESS FILE, and is treated as exactly that. Embedding it would
-    /// make an index pass silently pull the library down from iCloud, which is what `skipDataless`
-    /// exists to prevent; with the setting off, the download is allowed the same way a read-through
-    /// of an evicted file is. Nothing is deleted either way - an asset skipped here is still marked
-    /// seen by the crawl, so the sweep never mistakes it for removed.
-    private func decodePhoto(_ file: CrawledFile, ref: PhotoLibrary.Ref, settings: IndexSettings) -> DecodedItem {
-        guard let info = PhotoLibrary.info(ref) else { return DecodedItem(file: file) }   // gone from the library
-        let allowNetwork = !settings.skipDataless
-        guard info.isLocal || allowNetwork else { return DecodedItem(file: file) }
-        let category: FileKind = info.isVideo ? .video : .image
-        let kind = category.rawValue
-        var meta = (width: info.width, height: info.height, duration: info.duration)
-
-        if category == .image {
-            if settings.minImageDimension > 0, max(info.width, info.height) < settings.minImageDimension {
-                return DecodedItem(file: file)
-            }
-        } else if settings.minVideoSeconds > 0, info.duration < settings.minVideoSeconds {
-            return DecodedItem(file: file)
-        }
-
-        // Content dedup, keyed on the ASSET rather than its bytes. This is what makes an asset that
-        // belongs to two selected albums cost one forward pass: the second source's path arrives,
-        // finds the first's rows under the same key, and stores them rewritten. Hashing the bytes
-        // instead would mean materializing every asset just to discover that.
-        var contentKey: String? = nil
-        if Self.contentDedup, !settings.forceFreshEmbed {
-            let fp = category == .image
-                ? "d\(settings.maxImageDimension)"
-                : "v2|d\(settings.maxImageDimension)|f\(settings.maxVideoFrames)|s\(Int(Self.mediaSegmentSeconds))"
-            let ck = "2|photo|\(category.rawValue)|m\(embedder.dim)|t\(file.modified)|s\(file.size)|\(fp)|\(ref.localIdentifier)"
-            contentKey = ck
-            if let src = store.duplicateChunks(key: ck) {
-                noteDedupHit()
-                return DecodedItem(file: file, kind: kind, payload: .duplicate(Self.rewrite(src, to: file)),
-                                   meta: meta, contentKey: ck)
-            }
-        }
-
-        if category == .video {
-            guard let asset = PhotoLibrary.video(ref, allowNetwork: allowNetwork) else { return DecodedItem(file: file) }
-            // The asset's real duration and dimensions, now that it is open - PHAsset's are the
-            // ORIGINAL's, and an edit (a trim, a slow-motion ramp) changes both.
-            if let mi = FileExtractor.mediaInfo(asset: asset), mi.duration > 0 {
-                meta = (mi.width > 0 ? mi.width : meta.width, mi.height > 0 ? mi.height : meta.height, mi.duration)
-            }
-            if meta.duration.isFinite, meta.duration > Self.mediaSegmentSeconds {
-                return DecodedItem(file: file, kind: kind,
-                                   payload: .photoVideoSegments(asset: asset, duration: meta.duration,
-                                                                maxFrames: settings.maxVideoFrames,
-                                                                maxDimension: settings.maxImageDimension),
-                                   meta: meta, contentKey: contentKey)
-            }
-            let frames = FileExtractor.videoFrames(asset: asset, maxFrames: settings.maxVideoFrames,
-                                                   maxDimension: settings.maxImageDimension)
-            return frames.isEmpty ? DecodedItem(file: file)
-                                  : DecodedItem(file: file, kind: kind, payload: .images(frames),
-                                                meta: meta, contentKey: contentKey)
-        }
-
-        guard let image = PhotoLibrary.image(ref, maxDimension: settings.maxImageDimension,
-                                             allowNetwork: allowNetwork) else { return DecodedItem(file: file) }
-        // A row's width/height is the asset's OWN resolution, the same quality signal a file row
-        // carries (the file path stores the original's pixel size, not the downscaled decode).
-        // The decode is normally a pure downscale to maxImageDimension, and under Optimize Mac
-        // Storage it can be a smaller resident derivative still - reporting either as the photo's
-        // size would tell the UI and the serving layer that a 4000 px photo is a 1024 px one.
-        //
-        // The exception is an EDIT: a crop changes the framing, so the decoded aspect ratio stops
-        // matching the asset's and the decoded numbers are the ones describing the real picture.
-        let assetAR = info.height > 0 ? Double(info.width) / Double(info.height) : 0
-        let decodedAR = image.height > 0 ? Double(image.width) / Double(image.height) : 0
-        let sameFraming = assetAR > 0 && decodedAR > 0 && abs(assetAR - decodedAR) <= 0.01 * assetAR
-        meta = sameFraming ? (max(info.width, image.width), max(info.height, image.height), 0)
-                           : (image.width, image.height, 0)
-        let item = DecodedItem(file: file, kind: kind,
-                               payload: .imagePatches([OmniVisionPreprocess.preprocessRaw(image)]),
-                               meta: meta, contentKey: contentKey)
-        if settings.hqMediaTags {
-            item.hqCrops = OmniTagger.cwrCropRects(width: image.width, height: image.height)
-                .compactMap { image.cropping(to: $0) }
-                .map { OmniVisionPreprocess.preprocessRaw($0) }
-        }
-        return item
-    }
-
     /// Content key of a file: SHA-256 over the bytes that determine its embedding, qualified by
     /// every setting that changes the vectors for those bytes (and the model dimension). Plain
     /// text extraction truncates at FileExtractor.maxTextBytes, so the hash caps there for those
     /// extensions - exact, because chunks can only depend on bytes extract() actually reads.
     /// The extension is included so equal bytes under different parsers never alias. Nil on read
     /// failure (no dedup; the normal path decides what to do with the file).
-    private func contentKey(_ file: CrawledFile, category: FileKind, settings: IndexSettings) -> String? {
+    static func fileContentKey(_ file: CrawledFile, category: FileKind, dim: Int,
+                               chunkOverlap: Int, settings: IndexSettings) -> String? {
         let ext = file.ext.lowercased()
         let cap = (category == .text && FileExtractor.textExtensions.contains(ext)) ? FileExtractor.maxTextBytes : Int.max
-        guard let digest = Self.sha256(file.url, cap: cap) else { return nil }
+        guard let digest = sha256(file.url, cap: cap) else { return nil }
         let fp: String
         switch category {
         // .scan grouped for exhaustiveness only - contentKey is always called with the
@@ -1750,7 +1643,7 @@ public final class Indexer: @unchecked Sendable {
         case .text, .scan:  fp = "c\(settings.maxCharsPerChunk)|o\(chunkOverlap)|d\(settings.maxImageDimension)"   // d: scanned-PDF render size
         case .image: fp = "d\(settings.maxImageDimension)"
         // v2: uniform frame sampling + 240 s segmentation (pre-upgrade rows must not alias).
-        case .video: fp = "v2|d\(settings.maxImageDimension)|f\(settings.maxVideoFrames)|s\(Int(Self.mediaSegmentSeconds))"
+        case .video: fp = "v2|d\(settings.maxImageDimension)|f\(settings.maxVideoFrames)|s\(Int(mediaSegmentSeconds))"
         case .audio: fp = "s\(OmniAudioPreprocess.segmentMelFrames)"   // segmenting changes long-audio chunking
         }
         // SIZE is part of the identity, and the version is 2 because of it. The digest covers only
@@ -1759,7 +1652,7 @@ public final class Indexer: @unchecked Sendable {
         // other. Measured on a 212k-file index: 9 key groups / 35 files aliased that way, all
         // append-only session logs from 4.2 MB to 18.0 MB carrying one embedding between them.
         // Genuinely identical copies still dedup - equal bytes implies equal size.
-        return "2|\(category.rawValue)|\(ext)|m\(embedder.dim)|s\(file.size)|\(fp)|\(digest)"
+        return "2|\(category.rawValue)|\(ext)|m\(dim)|s\(file.size)|\(fp)|\(digest)"
     }
 
     /// Streaming SHA-256 of a file's first `cap` bytes (whole file when cap covers it).

--- a/Tests/OmniKitTests/ContentSourceTests.swift
+++ b/Tests/OmniKitTests/ContentSourceTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+import CoreGraphics
+@testable import OmniKit
+
+/// The ingestion-source contract.
+///
+/// These exist because issue #13 was not a PhotoKit bug, it was an ARCHITECTURE bug: a second
+/// ingestion channel restated the first one's policy and the restatement drifted. The protocol
+/// removes the opportunity, and these pin the properties a third channel (external disk, special
+/// folder, mail store) must not break.
+final class ContentSourceTests: XCTestCase {
+
+    private func file(_ path: String, modified: Double = 1_700_000_000, size: Int = 4096) -> CrawledFile {
+        CrawledFile(path: path, modified: modified, size: size)
+    }
+
+    private func photoPath(_ id: String = "AAAA1111-2222-3333-4444-555566667777/L0/001",
+                           source: String = "all", name: String = "IMG_1.HEIC") -> String {
+        PhotoLibrary.scheme + PhotoLibrary.esc(source) + "/" + PhotoLibrary.esc(id) + "/" + name
+    }
+
+    // MARK: - Routing
+
+    /// Exactly one source owns any item: the claims must partition, not overlap.
+    func testClaimsPartitionEveryPath() {
+        let disk = file("/Users/x/Pictures/holiday.heic")
+        let photo = file(photoPath())
+
+        XCTAssertTrue(FileContentSource.claims(disk))
+        XCTAssertFalse(PhotosContentSource.claims(disk))
+
+        XCTAssertTrue(PhotosContentSource.claims(photo))
+        XCTAssertFalse(FileContentSource.claims(photo))
+    }
+
+    func testResolutionPicksTheOwningSource() {
+        XCTAssertTrue(ContentSources.source(for: file("/tmp/a.txt")) is FileContentSource)
+        XCTAssertTrue(ContentSources.source(for: file(photoPath())) is PhotosContentSource)
+    }
+
+    /// A path that merely LOOKS like a photos path but does not parse must still get a source
+    /// rather than trapping - the fallback is what makes routing total.
+    func testUnparseablePhotoPathStillResolves() {
+        let malformed = file(PhotoLibrary.scheme + "not-a-valid-ref")
+        XCTAssertNotNil(ContentSources.source(for: malformed))
+    }
+
+    // MARK: - The invariant that broke (#13)
+
+    /// A source must never ask for MORE resolution than the item has. `FileExtractor.loadImage`
+    /// gets this free from `kCGImageSourceThumbnailMaxPixelSize` (a cap); the Photos path has to
+    /// clamp explicitly, because PhotoKit's `.exact` delivers whatever size it is asked for.
+    ///
+    /// This is the pipeline-parity property in its most testable form: same picture, same channel-
+    /// independent answer.
+    func testNoSourceUpscalesBeyondTheItem() {
+        for (w, h) in [(4032, 3024), (640, 480), (1568, 1568), (100, 4000)] {
+            let side = PhotoLibrary.targetSide(maxDimension: 1568, pixelWidth: w, pixelHeight: h)
+            XCTAssertLessThanOrEqual(side, max(w, h), "asked for more pixels than the \(w)x\(h) item has")
+            XCTAssertLessThanOrEqual(side, 1568, "exceeded maxImageDimension on a \(w)x\(h) item")
+        }
+    }
+
+    // MARK: - Content keys
+
+    /// Content keys are the dedup identity: equal key MUST mean equal embedding, so a key has to
+    /// move when anything that changes the vectors moves. Checked on the Photos source because its
+    /// key is derived (no byte hash available), which is where a drift would hide.
+    func testPhotoContentKeyTracksEverythingThatChangesTheVectors() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        let f = file(photoPath())
+        var settings = IndexSettings()
+
+        let base = src.contentKey(f, kind: .image, dim: 512, chunkOverlap: 200, settings: settings)
+        XCTAssertNotNil(base)
+
+        // Model dimension.
+        XCTAssertNotEqual(base, src.contentKey(f, kind: .image, dim: 256, chunkOverlap: 200, settings: settings))
+        // Preprocess size.
+        settings.maxImageDimension = 1024
+        XCTAssertNotEqual(base, src.contentKey(f, kind: .image, dim: 512, chunkOverlap: 200, settings: settings))
+        settings.maxImageDimension = 1568
+        // The tower that will run.
+        XCTAssertNotEqual(base, src.contentKey(f, kind: .video, dim: 512, chunkOverlap: 200, settings: settings))
+        // The asset's own mtime/size.
+        XCTAssertNotEqual(base, src.contentKey(file(photoPath(), modified: 1_700_000_001),
+                                               kind: .image, dim: 512, chunkOverlap: 200, settings: settings))
+        // A DIFFERENT asset must never share a key with this one.
+        let other = photoPath("BBBB1111-2222-3333-4444-555566667777/L0/001")
+        XCTAssertNotEqual(base, PhotosContentSource(ref: PhotoLibrary.Ref(other)!)
+            .contentKey(file(other), kind: .image, dim: 512, chunkOverlap: 200, settings: settings))
+    }
+
+    /// Same asset, same settings, twice: dedup only works if the key is stable.
+    func testPhotoContentKeyIsDeterministic() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        let f = file(photoPath())
+        let s = IndexSettings()
+        XCTAssertEqual(src.contentKey(f, kind: .image, dim: 512, chunkOverlap: 200, settings: s),
+                       src.contentKey(f, kind: .image, dim: 512, chunkOverlap: 200, settings: s))
+    }
+
+    /// The same asset reached through two different albums is the same content and must dedup to
+    /// one forward pass - the property that makes overlapping album selections cheap.
+    func testSameAssetInTwoAlbumsSharesAContentKey() {
+        let id = "CCCC1111-2222-3333-4444-555566667777/L0/001"
+        let viaAll = photoPath(id, source: "all")
+        let viaAlbum = photoPath(id, source: "5E2F5C3A-0000-4000-8000-000000000001/L0/040")
+        let s = IndexSettings()
+
+        let a = PhotosContentSource(ref: PhotoLibrary.Ref(viaAll)!)
+            .contentKey(file(viaAll), kind: .image, dim: 512, chunkOverlap: 200, settings: s)
+        let b = PhotosContentSource(ref: PhotoLibrary.Ref(viaAlbum)!)
+            .contentKey(file(viaAlbum), kind: .image, dim: 512, chunkOverlap: 200, settings: s)
+        XCTAssertEqual(a, b, "the same asset in two albums must embed once")
+    }
+
+    /// A file key and a photo key must never collide, whatever the inputs.
+    func testFileAndPhotoKeyspacesAreDisjoint() {
+        let s = IndexSettings()
+        let photoKey = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+            .contentKey(file(photoPath()), kind: .image, dim: 512, chunkOverlap: 200, settings: s)
+        XCTAssertEqual(photoKey?.hasPrefix("2|photo|"), true)
+
+        // The file keyspace is "2|<kind>|...", never "2|photo|...", because FileKind has no
+        // "photo" case - the kinds are text/image/audio/video/scan.
+        XCTAssertFalse(FileKind.allCases.contains { $0.rawValue == "photo" },
+                       "a FileKind named photo would collide with the Photos keyspace")
+    }
+
+    /// A missing file yields no key rather than a bogus one: no digest, no dedup, and the normal
+    /// path decides what to do. A key invented here would alias unrelated files.
+    func testFileContentKeyIsNilWhenTheFileCannotBeRead() {
+        let missing = file("/nonexistent-\(UUID().uuidString)/nope.txt")
+        XCTAssertNil(FileContentSource().contentKey(missing, kind: .text, dim: 512,
+                                                    chunkOverlap: 200, settings: IndexSettings()))
+    }
+
+    /// Text keys must move with the chunking parameters: the same bytes chunked differently are
+    /// different rows. This is the parameter the protocol has to thread through explicitly, so it
+    /// is the one most likely to be dropped by a future source.
+    func testFileTextKeyTracksChunkingParameters() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("omni-cs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("doc.txt")
+        try String(repeating: "search index content. ", count: 500).write(to: url, atomically: true, encoding: .utf8)
+
+        let f = CrawledFile(url: url, modified: 1_700_000_000, size: 11_000)
+        let src = FileContentSource()
+        var settings = IndexSettings()
+
+        let base = src.contentKey(f, kind: .text, dim: 512, chunkOverlap: 200, settings: settings)
+        XCTAssertNotNil(base)
+        XCTAssertEqual(base, src.contentKey(f, kind: .text, dim: 512, chunkOverlap: 200, settings: settings),
+                       "same file, same settings must be stable")
+        XCTAssertNotEqual(base, src.contentKey(f, kind: .text, dim: 512, chunkOverlap: 120, settings: settings),
+                          "overlap changes the chunks")
+        settings.maxCharsPerChunk = 900
+        XCTAssertNotEqual(base, src.contentKey(f, kind: .text, dim: 512, chunkOverlap: 200, settings: settings),
+                          "chunk size changes the chunks")
+    }
+
+    // MARK: - Probe / threshold policy
+
+    /// A dataless file must be refused BEFORE any content read: reading it would silently download
+    /// it, which is the whole point of the setting.
+    func testDatalessPolicyIsAnsweredByTheProbe() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("omni-cs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("plain.txt")
+        try "ordinary local text".write(to: url, atomically: true, encoding: .utf8)
+
+        // An ordinary local file is never dataless, under either policy.
+        let f = CrawledFile(url: url, modified: 1_700_000_000, size: 19)
+        var settings = IndexSettings()
+        settings.skipDataless = true
+        XCTAssertNotNil(FileContentSource().probe(f, settings: settings))
+        settings.skipDataless = false
+        XCTAssertNotNil(FileContentSource().probe(f, settings: settings))
+    }
+
+    /// `measured` is what stops a threshold from firing on a number nobody read. A text file has no
+    /// dimensions, so it must report false - otherwise a minImageDimension setting would start
+    /// silently dropping documents.
+    func testTextProbeReportsNoMeasurements() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("omni-cs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("doc.txt")
+        try "hello".write(to: url, atomically: true, encoding: .utf8)
+
+        let p = try XCTUnwrap(FileContentSource().probe(CrawledFile(url: url, modified: 0, size: 5),
+                                                        settings: IndexSettings()))
+        XCTAssertEqual(p.kind, .text)
+        XCTAssertFalse(p.measured)
+        XCTAssertEqual(p.width, 0)
+        XCTAssertEqual(p.height, 0)
+    }
+
+    /// An unreadable image header yields a probe with no measurements rather than nil: the item is
+    /// still THERE, it just cannot be sized, and the decode below may still extract something.
+    func testUnreadableImageHeaderIsNotTreatedAsMissing() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("omni-cs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("broken.png")
+        try Data("not actually a png".utf8).write(to: url)
+
+        let p = try XCTUnwrap(FileContentSource().probe(CrawledFile(url: url, modified: 0, size: 18),
+                                                        settings: IndexSettings()))
+        XCTAssertEqual(p.kind, .image)
+        XCTAssertFalse(p.measured, "a header that did not parse must not claim measurements")
+    }
+
+    // MARK: - Metadata after decode
+
+    /// Default policy: a row keeps the ORIGINAL's dimensions, because the decode is just a
+    /// downscale and the stored size is a quality signal.
+    func testDefaultMetaKeepsTheOriginalDimensions() {
+        let probe = SourceProbe(kind: .image, width: 4032, height: 3024, measured: true)
+        let decoded = CGContext(data: nil, width: 1568, height: 1176, bitsPerComponent: 8, bytesPerRow: 0,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!.makeImage()!
+        let meta = FileContentSource().metaAfterImageDecode(probe: probe, decoded: decoded)
+        XCTAssertEqual(meta.width, 4032)
+        XCTAssertEqual(meta.height, 3024)
+    }
+
+    /// Photos keeps the asset's dimensions for a plain downscale (same aspect ratio)...
+    func testPhotoMetaKeepsAssetDimensionsOnAPlainDownscale() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        let probe = SourceProbe(kind: .image, width: 4032, height: 3024, measured: true)
+        let decoded = CGContext(data: nil, width: 1568, height: 1176, bitsPerComponent: 8, bytesPerRow: 0,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!.makeImage()!
+        let meta = src.metaAfterImageDecode(probe: probe, decoded: decoded)
+        XCTAssertEqual(meta.width, 4032, "a downscaled decode must not shrink the reported photo")
+        XCTAssertEqual(meta.height, 3024)
+    }
+
+    /// ...but takes the decoded ones after an EDIT, where the asset's numbers no longer describe
+    /// the picture the user sees.
+    func testPhotoMetaFollowsTheDecodeAfterACrop() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        let probe = SourceProbe(kind: .image, width: 4032, height: 3024, measured: true)   // 4:3
+        let cropped = CGContext(data: nil, width: 1000, height: 1000, bitsPerComponent: 8, bytesPerRow: 0,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!.makeImage()!
+        let meta = src.metaAfterImageDecode(probe: probe, decoded: cropped)
+        XCTAssertEqual(meta.width, 1000, "a crop changes the framing; the decode is the truth")
+        XCTAssertEqual(meta.height, 1000)
+    }
+
+    /// An asset PhotoKit reported no dimensions for must not produce a zero-sized row when the
+    /// decode did yield an image.
+    func testPhotoMetaFallsBackToTheDecodeWhenTheAssetHasNoDimensions() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        let probe = SourceProbe(kind: .image, width: 0, height: 0, measured: true)
+        let decoded = CGContext(data: nil, width: 800, height: 600, bitsPerComponent: 8, bytesPerRow: 0,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!.makeImage()!
+        let meta = src.metaAfterImageDecode(probe: probe, decoded: decoded)
+        XCTAssertEqual(meta.width, 800)
+        XCTAssertEqual(meta.height, 600)
+    }
+
+    // MARK: - Modality coverage
+
+    /// The Photos library holds images and videos. Audio must be declined rather than faked, so the
+    /// shared decode falls through to "nothing to do" instead of embedding silence.
+    func testPhotosDeclinesAudio() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        XCTAssertNil(src.audio(file(photoPath()), probe: SourceProbe(kind: .audio), settings: IndexSettings()))
+    }
+
+    /// Photos content() only answers for stills - a video goes through video(), and asking
+    /// content() for one must not return an image payload.
+    func testPhotosContentDeclinesNonImageKinds() {
+        let src = PhotosContentSource(ref: PhotoLibrary.Ref(photoPath())!)
+        if case .empty = src.content(file(photoPath()), kind: .video, settings: IndexSettings()) {} else {
+            XCTFail("video must not be answered by content()")
+        }
+    }
+}

--- a/UITests/MixedSourceChaosUITests.swift
+++ b/UITests/MixedSourceChaosUITests.swift
@@ -1,0 +1,285 @@
+import XCTest
+import AppKit
+import AVFoundation
+
+/// Chaotic UI exercise over a MIXED-MODALITY corpus, driven while the index churns.
+///
+/// `ChaosUITests` covers a text-only corpus. This one exists for the ingestion refactor: every
+/// modality now reaches the store through one `decode()` and one `ContentSource`, so the shape that
+/// can break is no longer "text search misbehaves" but "one modality's rows disagree with another's
+/// after the paths were merged". Text, images of several sizes, and a video are indexed together,
+/// then the UI is driven across list and grid (the two views that read `hit.width/height`, which is
+/// exactly the metadata the refactor made a source-owned decision), with kind filters that force
+/// results from one modality at a time.
+///
+/// Isolation is `ChaosUITests`': launch arguments land in the NSUserDefaults ARGUMENT domain, which
+/// is process-local and never written back, so a run cannot touch a real install's index or roots.
+/// The Photos channel is deliberately NOT exercised - it needs TCC authorization that a test
+/// machine may not have granted, and a prompt would hang the run. Its logic is covered by
+/// `ContentSourceTests` and `PhotoTargetSizeTests`, which need no library.
+final class MixedSourceChaosUITests: XCTestCase {
+
+    private var root = URL(fileURLWithPath: NSTemporaryDirectory())
+    private var corpus = URL(fileURLWithPath: NSTemporaryDirectory())
+    private var scratchDB = URL(fileURLWithPath: NSTemporaryDirectory())
+    private var churnStop = false
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("omni-mixedchaos-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+        corpus = root.appendingPathComponent("corpus", isDirectory: true)
+        scratchDB = root.appendingPathComponent("db", isDirectory: true)
+        try FileManager.default.createDirectory(at: corpus, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: scratchDB, withIntermediateDirectories: true)
+
+        for i in 0 ..< 60 {
+            let body = (0 ..< 40).map { l in
+                "Line \(l) of document \(i): distributed vector search over quantized replicas, "
+                + "porsche sports car, quarterly revenue, memory budget, recipe with tomatoes."
+            }.joined(separator: "\n")
+            try body.write(to: corpus.appendingPathComponent("doc\(i).txt"), atomically: true, encoding: .utf8)
+        }
+
+        // Images ACROSS the maxImageDimension boundary (1568). The decode reduces a large one and
+        // leaves a small one alone, and after the refactor both go through the same source call -
+        // so both sizes have to survive indexing and render in the grid.
+        for (i, side) in [320, 900, 1600, 2400].enumerated() {
+            try writePNG(corpus.appendingPathComponent("pic\(i)-\(side).png"), width: side, height: side * 3 / 4)
+        }
+        try writeVideo(corpus.appendingPathComponent("clip.mov"))
+    }
+
+    override func tearDownWithError() throws {
+        churnStop = true
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: - Corpus builders
+
+    private func writePNG(_ url: URL, width: Int, height: Int) throws {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+                                  space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else {
+            throw XCTSkip("could not create a bitmap context")
+        }
+        // Some structure, so distinct images do not collapse into one content-dedup group.
+        for b in 0 ..< 24 {
+            ctx.setFillColor(red: CGFloat((b * 37) % 255) / 255.0,
+                             green: CGFloat((b * 91 + width) % 255) / 255.0,
+                             blue: CGFloat((b * 53 + height) % 255) / 255.0, alpha: 1)
+            ctx.fill(CGRect(x: CGFloat(b) * CGFloat(width) / 24.0, y: 0,
+                            width: CGFloat(width) / 24.0, height: CGFloat(height)))
+        }
+        guard let img = ctx.makeImage() else { throw XCTSkip("could not render a bitmap") }
+        let rep = NSBitmapImageRep(cgImage: img)
+        guard let data = rep.representation(using: .png, properties: [:]) else { throw XCTSkip("no PNG encoder") }
+        try data.write(to: url)
+    }
+
+    /// A short H.264 clip, so the video modality is genuinely present rather than mocked.
+    private func writeVideo(_ url: URL) throws {
+        let w = 320, h = 240
+        guard let writer = try? AVAssetWriter(outputURL: url, fileType: .mov) else {
+            throw XCTSkip("no AVAssetWriter")
+        }
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: w, AVVideoHeightKey: h,
+        ])
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: input, sourcePixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32ARGB),
+            kCVPixelBufferWidthKey as String: w, kCVPixelBufferHeightKey as String: h,
+        ])
+        guard writer.canAdd(input) else { throw XCTSkip("writer rejected the input") }
+        writer.add(input)
+        guard writer.startWriting() else { throw XCTSkip("writer did not start") }
+        writer.startSession(atSourceTime: .zero)
+
+        for f in 0 ..< 24 {
+            var pb: CVPixelBuffer?
+            guard let pool = adaptor.pixelBufferPool,
+                  CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pb) == kCVReturnSuccess,
+                  let buf = pb else { break }
+            CVPixelBufferLockBaseAddress(buf, [])
+            if let base = CVPixelBufferGetBaseAddress(buf),
+               let ctx = CGContext(data: base, width: w, height: h, bitsPerComponent: 8,
+                                   bytesPerRow: CVPixelBufferGetBytesPerRow(buf),
+                                   space: CGColorSpaceCreateDeviceRGB(),
+                                   bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue) {
+                ctx.setFillColor(red: CGFloat(f) / 24.0, green: 0.35, blue: 0.7, alpha: 1)
+                ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+            }
+            CVPixelBufferUnlockBaseAddress(buf, [])
+            while !input.isReadyForMoreMediaData { usleep(5_000) }
+            adaptor.append(buf, withPresentationTime: CMTime(value: CMTimeValue(f), timescale: 12))
+        }
+        input.markAsFinished()
+        let done = expectation(description: "video written")
+        writer.finishWriting { done.fulfill() }
+        wait(for: [done], timeout: 30)
+    }
+
+    // MARK: - Driving
+
+    private func launchIsolated() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-omni.dbDir", scratchDB.path,
+            "-omni.roots", "(\"\(corpus.path)\")",
+            "-omni.serving.enabled", "NO",
+            "-omni.uiChaos", "YES",
+        ]
+        app.launch()
+        return app
+    }
+
+    /// Churn across MODALITIES while the UI is driven: text edits, a new image, deletions and a
+    /// rename, so reconcile is handling several kinds at once rather than only text.
+    private func startChurn() {
+        churnStop = false
+        Thread.detachNewThread { [corpus] in
+            var n = 0
+            let fm = FileManager.default
+            while !self.churnStop {
+                switch n % 5 {
+                case 0:
+                    let f = corpus.appendingPathComponent("doc\(n % 60).txt")
+                    if let h = try? FileHandle(forWritingTo: f) {
+                        h.seekToEndOfFile(); h.write(Data("\nappended \(n)\n".utf8)); try? h.close()
+                    }
+                case 1:
+                    try? "fresh document \(n) about metal kernels"
+                        .write(to: corpus.appendingPathComponent("new\(n).txt"), atomically: true, encoding: .utf8)
+                case 2:
+                    try? self.writePNG(corpus.appendingPathComponent("churn\(n).png"),
+                                       width: 200 + (n % 5) * 130, height: 180 + (n % 3) * 90)
+                case 3:
+                    try? fm.removeItem(at: corpus.appendingPathComponent("new\(n - 2).txt"))
+                default:
+                    try? fm.moveItem(at: corpus.appendingPathComponent("churn\(n - 2).png"),
+                                     to: corpus.appendingPathComponent("moved\(n).png"))
+                }
+                n += 1
+                Thread.sleep(forTimeInterval: 0.5)
+            }
+        }
+    }
+
+    private func focusSearch(_ app: XCUIApplication) {
+        let field = app.windows.firstMatch.searchFields.firstMatch
+        if field.exists, field.isHittable { field.click() } else { app.typeKey("f", modifierFlags: .command) }
+        usleep(150_000)
+    }
+
+    private func clearQuery(_ app: XCUIApplication) {
+        focusSearch(app)
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey(XCUIKeyboardKey.delete, modifierFlags: [])
+    }
+
+    func testMixedModalityChaosUnderIndexing() throws {
+        let app = launchIsolated()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 60), "app did not come up")
+        startChurn()
+
+        // Kind filters force the UI to render rows from ONE modality at a time - the case where a
+        // modality whose metadata regressed shows up as an empty or broken row rather than being
+        // hidden among text hits.
+        let queries = ["porsche", "type:image", "type:video", "type:text metal kernels",
+                       "memory budget", "type:image colorful stripes", "recipe tomatoes"]
+        let deadline = Date().addingTimeInterval(180)
+        var rounds = 0
+
+        while Date() < deadline {
+            switch rounds % 7 {
+            case 0:
+                // Search as you type, then abandon part way.
+                clearQuery(app)
+                for ch in queries[rounds % queries.count] {
+                    app.typeText(String(ch))
+                    usleep(UInt32.random(in: 25_000 ... 90_000))
+                }
+                usleep(UInt32.random(in: 200_000 ... 800_000))
+                app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+            case 1:
+                // Flip between list and grid WITH media on screen. Grid reads the stored pixel
+                // size for every cell, so a modality whose meta regressed shows up here.
+                clearQuery(app)
+                app.typeText("type:image")
+                usleep(900_000)
+                for _ in 0 ..< 3 {
+                    app.typeKey("1", modifierFlags: .command); usleep(350_000)
+                    app.typeKey("2", modifierFlags: .command); usleep(350_000)
+                }
+            case 2:
+                // Modality switch storm: never let one kind's results settle before asking for the
+                // next. Each switch re-runs the query against a different slice of the store.
+                for q in ["type:image", "type:video", "type:text", "type:image"] {
+                    clearQuery(app)
+                    app.typeText(q)
+                    usleep(220_000)
+                }
+            case 3:
+                // Walk results and open a preview - the path that materializes an actual item.
+                clearQuery(app)
+                app.typeText("type:image")
+                usleep(800_000)
+                app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+                for _ in 0 ..< Int.random(in: 2 ... 5) {
+                    app.typeKey(XCUIKeyboardKey.downArrow, modifierFlags: [])
+                    usleep(90_000)
+                }
+                app.typeText(" ")            // Quick Look
+                usleep(700_000)
+                app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+            case 4:
+                // Toolbar controls by position, scoped to the toolbar so the driver's own
+                // "_XCUI:CloseWindow" is never clicked (it took the app down in ChaosUITests).
+                let buttons = app.windows.firstMatch.toolbars.firstMatch.buttons
+                let safe = (0 ..< buttons.count).map { buttons.element(boundBy: $0) }.filter {
+                    guard $0.exists else { return false }
+                    return !$0.identifier.hasPrefix("_XCUI")
+                }
+                if let b = safe.randomElement(), b.isHittable { b.click() }
+                usleep(300_000)
+                app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+            case 5:
+                // Escape spam then refocus: the state machine sees stop, stop, stop, start.
+                for _ in 0 ..< 5 { app.typeKey(XCUIKeyboardKey.escape, modifierFlags: []); usleep(60_000) }
+                clearQuery(app)
+                app.typeText("m")
+            default:
+                let rows = app.windows.firstMatch.outlines.firstMatch.cells
+                if rows.count > 0 {
+                    let r = rows.element(boundBy: Int.random(in: 0 ..< min(rows.count, 4)))
+                    if r.exists, r.isHittable { r.click() }
+                }
+                usleep(300_000)
+            }
+
+            rounds += 1
+            // "The app died" and "the driver closed its window" look identical from here.
+            guard app.state == .runningForeground else {
+                XCTFail("app left the foreground after round \(rounds) (state \(app.state.rawValue)); "
+                        + "windows=\(app.windows.count)")
+                return
+            }
+        }
+
+        churnStop = true
+        sleep(2)
+
+        // Still WORKING at the end, not merely still alive - and working for every modality, which
+        // is the property the single decode path is responsible for.
+        for q in ["type:text", "type:image", "porsche"] {
+            clearQuery(app)
+            app.typeText(q)
+            sleep(3)
+            XCTAssertEqual(app.state, .runningForeground, "app died running \(q)")
+            XCTAssertTrue(app.windows.firstMatch.exists, "window gone running \(q)")
+        }
+        print("[mixed-chaos] completed \(rounds) interaction rounds")
+    }
+}


### PR DESCRIPTION
Follows #15. Stacked on it (that branch is the base), so review #15 first.

## Why

#13 was not really a PhotoKit bug. It was a *second ingestion channel that restated the first one's policy and drifted*. `decodePhoto` was a 78-line parallel copy of `decode`: its own thresholds, its own dedup short-circuit, its own payload construction, its own metadata rules. One line in that copy asked PhotoKit for `.highQualityFormat` ("as asked or better") where the file path asks CoreGraphics for a cap ("best available, no larger than"), and ~40,000 photos indexed as ~150.

Adding an external disk or a special folder as a third `decodeXxx` branch would repeat this. So the two paths are now one.

## The split

`ContentSource` owns only what is genuinely source-specific:

| | |
|---|---|
| `probe` | kind + original dimensions; nil = skip now (gone, or would need a download) |
| `contentKey` | identity of the bytes that determine the embedding |
| `content` | text / stills / scanned-PDF handle |
| `video` / `audio` | frames or a segment plan |
| `metaAfterImageDecode` | what dimensions to store (defaulted) |

`Indexer.decode` owns everything that is **policy**, exactly once: index-time minimums, the content-dedup short-circuit, payload shape, chunking, HQ tag crops, the byte budget. A new channel implements the protocol and inherits all of it. It cannot acquire its own version of it, which is the property that was missing.

Two design points worth flagging:

- **`probe` returns `SourceProbe?`, folding readability into the same call.** Readability and metrics are the same expensive question for PhotoKit - both come from one `PhotoLibrary.info`. A separate `isReadable` would have doubled the round trips per asset, which is measurable across a six-figure library.
- **`SourceProbe.measured`** distinguishes "0x0 because text" from "0x0 because the header would not parse". Thresholds only apply to metrics a source actually read, preserving today's behavior where an unparseable file is never threshold-dropped.

## Result

`Indexer.swift`: **+47 / -154**. `decodePhoto` is gone; the Indexer no longer imports PhotoKit concepts at all.

## Tests

**`ContentSourceTests`, 19 new** - the invariants that keep a future channel from re-drifting:

- exactly one source claims any path, `photos://` and file paths route correctly
- content keys are stable, and change when dimension / frames / model dim / chunk overlap / size / extension change
- a Photos key and a file key can never collide
- default `metaAfterImageDecode` keeps the probe's dimensions (the downscale case)
- the Photos override keeps asset dimensions on a pure downscale and switches to decoded dimensions past the 1% aspect-ratio threshold (the crop case)
- `measured` is false for text and for unparseable headers

**Full unit suite: 211 tests, 0 failures** (192 baseline + 19; 15 skipped, they need the model dir).

**`MixedSourceChaosUITests`, new** - `ChaosUITests` is text-only, and after this refactor the interesting failure is cross-modality disagreement. Indexes text + PNGs on both sides of the 1568 px boundary + a generated video, then drives list/grid switching (grid reads `hit.width/height`, exactly the source-owned decision) and per-kind filters while the corpus churns. **Passed: 37 rounds, 205 s.**

The Photos channel is deliberately excluded from the UI test: it needs TCC authorization a test machine may not have, and a prompt would hang the run. Its logic is covered by the unit tests, which need no library.

## Note for reviewers

`Scripts/run-tests.sh` has a stale hardcoded artifact path (`swift-tokeni…Rust.artifactbundle`); the real one is `swift-tokenizers/TokenizersRust/TokenizersRust.artifactbundle`. It also crashes on `FILTER[@]` under `set -u` when run with no filter. Both are pre-existing and left alone here rather than mixed into this diff.